### PR TITLE
Fix none unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@
 [![Coverage Info](https://coveralls.io/repos/github/cedar-team/pyredox/badge.svg?branch=main)](https://coveralls.io/github/cedar-team/pyredox?branch=main)
 [![Black Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Pyredox is library for producing, ingesting, and validating data from [Redox], a
-"data platform designed to connect providers, payers and products."
+Pyredox is library for producing, ingesting, and validating data from [Redox], a "data platform designed to connect
+providers, payers and products."
 
-Pyredox is a set of [Pydantic] models that conforms to the [Redox data model]
-specification for the purpose of making it easy to convert Redox-formatted JSON to
-Python objects and vice versa. Because pyredox inherits the functionality of
-Pydantic, it validates that the JSON data conforms to the spec automatically upon
-object creation.
+Pyredox is a set of [Pydantic] models that conforms to the [Redox data model] specification for the purpose of making it
+easy to convert Redox-formatted JSON to Python objects and vice versa. Because pyredox inherits the functionality of
+Pydantic, it validates that the JSON data conforms to the spec automatically upon object creation.
 
 For example, if you tried to create a [`NewPatient`
-model](https://developer.redoxengine.com/data-models/PatientAdmin.html#NewPatient) with
-insufficient data, you would get an error like this:
+model](https://developer.redoxengine.com/data-models/PatientAdmin.html#NewPatient) with insufficient data, you would get
+an error like this:
 
-```python
+```
 >>> from pyredox.patientadmin.newpatient import NewPatient
 >>> NewPatient(Meta={})
 
@@ -31,11 +29,39 @@ Patient
   field required (type=value_error.missing)
 ```
 
+[Redox]: https://www.redoxengine.com/
+
+[Redox data model]: https://developer.redoxengine.com/data-models/index.html
+
+[Pydantic]: https://pydantic-docs.helpmanual.io/
 
 ## Usage
 
-The simplest way to create a `pyredox` model from a JSON payload is to pass an
-unpacked `dict` as the parameter when initializing the object, like this:
+There are two primary methods to create a `pyredox` object:
+
+1. [JSON Dict Expansion](#json-dict-expansion):
+    - Benefits:
+        - Simple to use if you already have a JSON string or dictionary (or list of dictionaries) and want to get the
+          `pyredox` object that corresponds to that payload.
+        - Options for if you already know the Redox type of the JSON payload and options for if you don't.
+    - Shortcomings:
+        - Writing out or creating a full JSON payload can be quite verbose if you're crafting it yourself (vs processing
+          a received payload).
+
+2. [Generic Objects](#using-generics):
+    - Benefits:
+        - Very composable; objects for sub-objects can be created separately from the Event Type model you're building.
+    - Shortcomings:
+        - Validation of the field values against the original Redox schema isn't fully performed until you call one of
+          the `to_redox()`, `dict()`, or `json()` methods.
+
+For instructions on how to serialize an object, see the [Serialize to JSON or `dict`](#serialize-to-json-or-dict)
+section down below.
+
+### JSON Dict Expansion
+
+The simplest way to create a `pyredox` model from a JSON payload is to pass an unpacked `dict` as the parameter when
+initializing the object, like this:
 
 ```python
 payload_str = """
@@ -58,8 +84,8 @@ data = json.loads(payload_str)
 new_patient = NewPatient(**data)
 ```
 
-If you have a payload and don't know which object type it is, you can use the
-factory helper, which can take a JSON string or the loaded JSON dict/list:
+If you have a payload and don't know which object type it is, you can use the factory helper, which can take a JSON
+string or the loaded JSON dict/list:
 
 ```python
 from pyredox.factory import redox_object_factory
@@ -68,21 +94,189 @@ redox_object1 = redox_object_factory(payload_str)  # str input
 redox_object2 = redox_object_factory(data)  # dict input
 ```
 
-To create a JSON payload to send to Redox from an existing `pyredox` object, just
-call the `json()` method of the object:
+To create a JSON payload to send to Redox from an existing `pyredox` object, just call the `json()` method of the
+object:
 
 ```python
 new_patient.json()
 ```
 
-When working with the individual fields of a model object, you can traverse the
-element properties like so:
+When working with the individual fields of a model object, you can traverse the element properties like so:
 
 ```python
 new_patient.patient.identifiers[0].id  # "e167267c-16c9-4fe3-96ae-9cff5703e90a"
 ```
 
+### Using Generics
 
-[Redox]: https://www.redoxengine.com/
-[Redox data model]: https://developer.redoxengine.com/data-models/index.html
-[Pydantic]: https://pydantic-docs.helpmanual.io/
+The Redox schema redefines every property of the Event Types in every location they're used. This is the case whether
+the property definitions are exactly the same or have slight differences. In order to make sure that every Event Type
+class in the library would perform structure validation exactly as defined in the schema, the "proper Redox" classes (my
+term for all Redox objects *not* residing in the `generic` folder) all have their own property class definitions that
+match the schema. This means that there are classes that have the exact same fields that exist in the same Python file
+and fall under the same Event Type.
+
+For example, in `pyredox/provider/new.py`, the `NewProviderRoleLocationAddress` and `NewProviderRoleOrganizationAddress`
+classes have the exact same definition because they're both Addresses. However, because one represents the address of
+the location for a provider's role and the other represents the address of the organization for the provider's role,
+Redox treats them differently. In contrast, most Event Types' `Meta` properties have similar but different fields,
+although all of them have the required `DataModel` and `EventType` fields.
+
+Because of all this, it becomes quite difficult to write a program that can build up a Redox message from multiple data
+sources without coupling with it a knowledge of the exact message you're creating. And even then the code can become
+very unwieldy with sprawling Python dictionaries.
+
+The solution is to use the Event Type classes and property classes defined in the `generic` directory. So, instead of
+creating a new provider like this:
+
+```python
+# THIS IS THE HARDER WAY TO DO THINGS!
+from pyredox.provider import New
+from pyredox.provider.new import (
+    NewMeta,
+    NewProvider,
+    NewProviderIdentifier,
+    NewProviderRole,
+    NewProviderRoleLocation,
+    NewProviderRoleLocationAddress,
+    NewProviderRoleOrganization,
+    NewProviderRoleOrganizationAddress,
+)
+
+provider_org = NewProviderRoleOrganization(
+    Address=NewProviderRoleOrganizationAddress(
+        StreetAddress="123 Cherry St",
+        City="Green Bay",
+        State="Wisconsin",
+        ZIP="54321",
+        Country="USA",
+    )
+)
+provider_loc1 = NewProviderRoleLocation(
+    Address=NewProviderRoleLocationAddress(
+        StreetAddress="123 Cherry St",
+        City="Green Bay",
+        State="Wisconsin",
+        ZIP="54321",
+        Country="USA",
+    ),
+)
+provider_loc2 = NewProviderRoleLocation(
+    Address=NewProviderRoleLocationAddress(
+        StreetAddress="567 Splenda Way",
+        City="Green Bay",
+        State="Wisconsin",
+        ZIP="54321",
+        Country="USA",
+    )
+)
+provider = NewProvider(
+    Identifiers=[NewProviderIdentifier(ID="FakeProviderID")],
+    IsActive=True,
+    Roles=[
+        NewProviderRole(
+            Organization=provider_org,
+            Locations=[provider_loc1, provider_loc2],
+        )
+    ],
+)
+
+new_provider_msg = New(
+    Meta=NewMeta(DataModel="Provider", EventType="New", Test=True),
+    Providers=[provider],
+)
+```
+
+The following is more composable and somewhat simpler:
+
+```python
+# Simpler way to create a new Provider
+from pyredox.generic import types as pyredox_types
+from pyredox.generic.Provider import New as NewProvider
+
+# Because office_address is a generic Address type, we can reuse it for both
+# the Organization and the Location for this Provider.
+office_address = pyredox_types.Address(
+    StreetAddress="123 Cherry St",
+    City="Green Bay",
+    State="Wisconsin",
+    ZIP="54321",
+    Country="USA",
+)
+clinic_address = pyredox_types.Address(
+    StreetAddress="567 Splenda Way",
+    City="Green Bay",
+    State="Wisconsin",
+    ZIP="54321",
+    Country="USA",
+)
+provider_org = pyredox_types.Organization(Address=office_address)
+provider_loc1 = pyredox_types.Location(Address=office_address)
+provider_loc2 = pyredox_types.Location(Address=clinic_address)
+provider = pyredox_types.Provider(
+    Identifiers=[pyredox_types.Identifier(ID="FakeProviderID")],
+    IsActive=True,
+    Roles=[
+        pyredox_types.Role(
+            Organization=provider_org,
+            Locations=[provider_loc1, provider_loc2],
+        )
+    ],
+)
+
+new_provider_msg = NewProvider(
+    Meta=pyredox_types.Meta(DataModel="Provider", EventType="New", Test=True),
+    Providers=[provider],
+).to_redox()  # This converts the object to a "proper Redox" model
+```
+
+It's important to note here that both the `.dict()` and `.json()` methods of the generic Event Type classes
+automatically convert the data to the "proper Redox" form first, so that last statement could also be written like this:
+
+```python
+new_provider_json = NewProvider(
+    Meta=pyredox_types.Meta(DataModel="Provider", EventType="New", Test=True),
+    Providers=[provider],
+).json()  # This converts the object to a "proper Redox" model, then gets the JSON string
+```
+
+There is a chance that, by using the generic types to build up the Redox message in a composable way, you may introduce
+fields that are available in the generic version of the object that are not defined in the "proper Redox" model. The
+library's default behavior is to silently drop those fields with no current plans to make this configurable.
+
+There's also a possibility that the "proper Redox" object you're building specifies a data type for a field that differs
+from other models that use that data type, which is a result of how the schema is specified. For example, the
+[generic `Demographics` class has the following field definition]([https://github.com/cedar-team/pyredox/blob/341407063f27d3b82000bcb86362ec00ce48dec2/pyredox/generic/types.py#L644]):
+
+```python
+EmailAddresses: Union[List["EmailAddress"], List[str]]
+```
+
+Some Event Type models specify a list of strings and others require an `EmailAddress` object. Currently, the only way to
+detect when such a type mismatch occurs is to catch the `pydantic.ValidationError` exception, like this:
+
+```python
+from pydantic import ValidationError
+
+try:
+    new_provider_json = NewProvider(
+        Meta=pyredox_types.Meta(DataModel="Provider", EventType="New", Test=True),
+        Providers=[provider],
+    ).json()  # This converts the object to a "proper Redox" model
+except ValidationError:
+    # TODO: Handle the validation error here
+    pass
+```
+
+### Serialize to JSON or `dict`
+
+All `pyredox` objects have methods that allow for easy serialization:
+- For the `dict` version of an object, call the `dict()` method.
+- For the JSON `str` version of an object, call the `json()` method.
+
+To customize how `pyredox` exports the data from your model, you can use any of the [parameters available from the
+underlying Pydantic models](https://pydantic-docs.helpmanual.io/usage/exporting_models/). Note that when calling the
+`json()` method, you can also include keyword arguments to be passed to the `json.dumps()`.
+
+When serializing generic types, be aware that `pyredox` will convert the object to the corresponding "proper Redox"
+before returning the serialized data. See above for more information.

--- a/pyredox/clinicaldecisions/request.py
+++ b/pyredox/clinicaldecisions/request.py
@@ -225,7 +225,7 @@ class RequestUnsignedMedicationOrder(RedoxAbstractModel):
     Priority: Union[str, None] = Field(None)
     Product: "RequestUnsignedMedicationOrderProduct" = Field(None)
     Questions: List["RequestUnsignedMedicationOrderQuestion"] = Field(None)
-    Route: Union[None] = Field(None)
+    Route: Union[str, None] = Field(None)
     StartDate: Union[str, None] = Field(None)
 
 

--- a/pyredox/clinicalsummary/patientpush.py
+++ b/pyredox/clinicalsummary/patientpush.py
@@ -313,16 +313,16 @@ class PatientPushCareTeamMemberRoleAltCode(RedoxAbstractModel):
 
 class PatientPushCareTeamMemberTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushCareTeamOrganization(RedoxAbstractModel):
 
     Address: "PatientPushCareTeamOrganizationAddress" = Field(None)
     Identifiers: List["PatientPushCareTeamOrganizationIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientPushCareTeamOrganizationTelecom"] = Field(None)
     Type: "PatientPushCareTeamOrganizationType" = Field(None)
 
@@ -345,9 +345,9 @@ class PatientPushCareTeamOrganizationIdentifier(RedoxAbstractModel):
 
 class PatientPushCareTeamOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushCareTeamOrganizationType(RedoxAbstractModel):
@@ -463,9 +463,9 @@ class PatientPushEncounterLocationIdentifier(RedoxAbstractModel):
 
 class PatientPushEncounterLocationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushEncounterLocationType(RedoxAbstractModel):
@@ -829,8 +829,8 @@ class PatientPushGoalPriority(RedoxAbstractModel):
 
 class PatientPushHeader(RedoxAbstractModel):
 
-    DirectAddressFrom: Union[None] = Field(None)
-    DirectAddressTo: Union[None] = Field(None)
+    DirectAddressFrom: Union[str, None] = Field(None)
+    DirectAddressTo: Union[str, None] = Field(None)
     Document: "PatientPushHeaderDocument" = Field(None)
     PCP: "PatientPushHeaderPCP" = Field(None)
     Patient: "PatientPushHeaderPatient" = Field(None)
@@ -899,7 +899,7 @@ class PatientPushHeaderDocumentCustodian(RedoxAbstractModel):
 
     Address: "PatientPushHeaderDocumentCustodianAddress" = Field(None)
     Identifiers: List["PatientPushHeaderDocumentCustodianIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientPushHeaderDocumentCustodianTelecom"] = Field(None)
     Type: "PatientPushHeaderDocumentCustodianType" = Field(None)
 
@@ -922,9 +922,9 @@ class PatientPushHeaderDocumentCustodianIdentifier(RedoxAbstractModel):
 
 class PatientPushHeaderDocumentCustodianTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushHeaderDocumentCustodianType(RedoxAbstractModel):
@@ -1127,7 +1127,7 @@ class PatientPushHeaderPatientOrganization(RedoxAbstractModel):
 
     Address: "PatientPushHeaderPatientOrganizationAddress" = Field(None)
     Identifiers: List["PatientPushHeaderPatientOrganizationIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientPushHeaderPatientOrganizationTelecom"] = Field(None)
     Type: "PatientPushHeaderPatientOrganizationType" = Field(None)
 
@@ -1150,9 +1150,9 @@ class PatientPushHeaderPatientOrganizationIdentifier(RedoxAbstractModel):
 
 class PatientPushHeaderPatientOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushHeaderPatientOrganizationType(RedoxAbstractModel):
@@ -1187,8 +1187,8 @@ class PatientPushHealthConcern(RedoxAbstractModel):
     StartDate: Union[str, None] = Field(None)
     Status: Union[str, None] = Field(None)
     TargetSite: "PatientPushHealthConcernTargetSite" = Field(None)
-    Units: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    Units: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientPushHealthConcernAltCode(RedoxAbstractModel):
@@ -2245,7 +2245,7 @@ class PatientPushResultProducerAddress(RedoxAbstractModel):
 
 class PatientPushResultSpecimen(RedoxAbstractModel):
 
-    CollectionDateTime: Union[None] = Field(None)
+    CollectionDateTime: Union[str, None] = Field(None)
     Identifiers: List[str] = Field(None)
     Source: "PatientPushResultSpecimenSource" = Field(None)
     TargetSite: "PatientPushResultSpecimenTargetSite" = Field(None)

--- a/pyredox/clinicalsummary/patientqueryresponse.py
+++ b/pyredox/clinicalsummary/patientqueryresponse.py
@@ -311,9 +311,9 @@ class PatientQueryResponseCareTeamMemberRoleAltCode(RedoxAbstractModel):
 
 class PatientQueryResponseCareTeamMemberTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseCareTeamOrganization(RedoxAbstractModel):
@@ -322,7 +322,7 @@ class PatientQueryResponseCareTeamOrganization(RedoxAbstractModel):
     Identifiers: List["PatientQueryResponseCareTeamOrganizationIdentifier"] = Field(
         None
     )
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientQueryResponseCareTeamOrganizationTelecom"] = Field(None)
     Type: "PatientQueryResponseCareTeamOrganizationType" = Field(None)
 
@@ -345,9 +345,9 @@ class PatientQueryResponseCareTeamOrganizationIdentifier(RedoxAbstractModel):
 
 class PatientQueryResponseCareTeamOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseCareTeamOrganizationType(RedoxAbstractModel):
@@ -467,9 +467,9 @@ class PatientQueryResponseEncounterLocationIdentifier(RedoxAbstractModel):
 
 class PatientQueryResponseEncounterLocationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseEncounterLocationType(RedoxAbstractModel):
@@ -914,7 +914,7 @@ class PatientQueryResponseHeaderDocumentCustodian(RedoxAbstractModel):
     Identifiers: List["PatientQueryResponseHeaderDocumentCustodianIdentifier"] = Field(
         None
     )
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientQueryResponseHeaderDocumentCustodianTelecom"] = Field(None)
     Type: "PatientQueryResponseHeaderDocumentCustodianType" = Field(None)
 
@@ -937,9 +937,9 @@ class PatientQueryResponseHeaderDocumentCustodianIdentifier(RedoxAbstractModel):
 
 class PatientQueryResponseHeaderDocumentCustodianTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseHeaderDocumentCustodianType(RedoxAbstractModel):
@@ -1093,7 +1093,7 @@ class PatientQueryResponseHeaderPatientOrganization(RedoxAbstractModel):
     Identifiers: List[
         "PatientQueryResponseHeaderPatientOrganizationIdentifier"
     ] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["PatientQueryResponseHeaderPatientOrganizationTelecom"] = Field(None)
     Type: "PatientQueryResponseHeaderPatientOrganizationType" = Field(None)
 
@@ -1116,9 +1116,9 @@ class PatientQueryResponseHeaderPatientOrganizationIdentifier(RedoxAbstractModel
 
 class PatientQueryResponseHeaderPatientOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseHeaderPatientOrganizationType(RedoxAbstractModel):
@@ -1155,8 +1155,8 @@ class PatientQueryResponseHealthConcern(RedoxAbstractModel):
     StartDate: Union[str, None] = Field(None)
     Status: Union[str, None] = Field(None)
     TargetSite: "PatientQueryResponseHealthConcernTargetSite" = Field(None)
-    Units: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    Units: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class PatientQueryResponseHealthConcernAltCode(RedoxAbstractModel):
@@ -2162,7 +2162,7 @@ class PatientQueryResponseResultProducerAddress(RedoxAbstractModel):
 
 class PatientQueryResponseResultSpecimen(RedoxAbstractModel):
 
-    CollectionDateTime: Union[None] = Field(None)
+    CollectionDateTime: Union[str, None] = Field(None)
     Identifiers: List[str] = Field(None)
     Source: "PatientQueryResponseResultSpecimenSource" = Field(None)
     TargetSite: "PatientQueryResponseResultSpecimenTargetSite" = Field(None)

--- a/pyredox/clinicalsummary/visitpush.py
+++ b/pyredox/clinicalsummary/visitpush.py
@@ -387,16 +387,16 @@ class VisitPushCareTeamMemberRoleAltCode(RedoxAbstractModel):
 
 class VisitPushCareTeamMemberTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushCareTeamOrganization(RedoxAbstractModel):
 
     Address: "VisitPushCareTeamOrganizationAddress" = Field(None)
     Identifiers: List["VisitPushCareTeamOrganizationIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitPushCareTeamOrganizationTelecom"] = Field(None)
     Type: "VisitPushCareTeamOrganizationType" = Field(None)
 
@@ -419,9 +419,9 @@ class VisitPushCareTeamOrganizationIdentifier(RedoxAbstractModel):
 
 class VisitPushCareTeamOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushCareTeamOrganizationType(RedoxAbstractModel):
@@ -662,9 +662,9 @@ class VisitPushEncounterLocationIdentifier(RedoxAbstractModel):
 
 class VisitPushEncounterLocationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushEncounterLocationType(RedoxAbstractModel):
@@ -1028,8 +1028,8 @@ class VisitPushGoalPriority(RedoxAbstractModel):
 
 class VisitPushHeader(RedoxAbstractModel):
 
-    DirectAddressFrom: Union[None] = Field(None)
-    DirectAddressTo: Union[None] = Field(None)
+    DirectAddressFrom: Union[str, None] = Field(None)
+    DirectAddressTo: Union[str, None] = Field(None)
     Document: "VisitPushHeaderDocument" = Field(None)
     PCP: "VisitPushHeaderPCP" = Field(None)
     Patient: "VisitPushHeaderPatient" = Field(None)
@@ -1098,7 +1098,7 @@ class VisitPushHeaderDocumentCustodian(RedoxAbstractModel):
 
     Address: "VisitPushHeaderDocumentCustodianAddress" = Field(None)
     Identifiers: List["VisitPushHeaderDocumentCustodianIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitPushHeaderDocumentCustodianTelecom"] = Field(None)
     Type: "VisitPushHeaderDocumentCustodianType" = Field(None)
 
@@ -1121,9 +1121,9 @@ class VisitPushHeaderDocumentCustodianIdentifier(RedoxAbstractModel):
 
 class VisitPushHeaderDocumentCustodianTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushHeaderDocumentCustodianType(RedoxAbstractModel):
@@ -1324,7 +1324,7 @@ class VisitPushHeaderPatientOrganization(RedoxAbstractModel):
 
     Address: "VisitPushHeaderPatientOrganizationAddress" = Field(None)
     Identifiers: List["VisitPushHeaderPatientOrganizationIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitPushHeaderPatientOrganizationTelecom"] = Field(None)
     Type: "VisitPushHeaderPatientOrganizationType" = Field(None)
 
@@ -1347,9 +1347,9 @@ class VisitPushHeaderPatientOrganizationIdentifier(RedoxAbstractModel):
 
 class VisitPushHeaderPatientOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushHeaderPatientOrganizationType(RedoxAbstractModel):
@@ -1384,8 +1384,8 @@ class VisitPushHealthConcern(RedoxAbstractModel):
     StartDate: Union[str, None] = Field(None)
     Status: Union[str, None] = Field(None)
     TargetSite: "VisitPushHealthConcernTargetSite" = Field(None)
-    Units: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    Units: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitPushHealthConcernAltCode(RedoxAbstractModel):
@@ -2539,7 +2539,7 @@ class VisitPushResultProducerAddress(RedoxAbstractModel):
 
 class VisitPushResultSpecimen(RedoxAbstractModel):
 
-    CollectionDateTime: Union[None] = Field(None)
+    CollectionDateTime: Union[str, None] = Field(None)
     Identifiers: List[str] = Field(None)
     Source: "VisitPushResultSpecimenSource" = Field(None)
     TargetSite: "VisitPushResultSpecimenTargetSite" = Field(None)

--- a/pyredox/clinicalsummary/visitqueryresponse.py
+++ b/pyredox/clinicalsummary/visitqueryresponse.py
@@ -387,16 +387,16 @@ class VisitQueryResponseCareTeamMemberRoleAltCode(RedoxAbstractModel):
 
 class VisitQueryResponseCareTeamMemberTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseCareTeamOrganization(RedoxAbstractModel):
 
     Address: "VisitQueryResponseCareTeamOrganizationAddress" = Field(None)
     Identifiers: List["VisitQueryResponseCareTeamOrganizationIdentifier"] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitQueryResponseCareTeamOrganizationTelecom"] = Field(None)
     Type: "VisitQueryResponseCareTeamOrganizationType" = Field(None)
 
@@ -419,9 +419,9 @@ class VisitQueryResponseCareTeamOrganizationIdentifier(RedoxAbstractModel):
 
 class VisitQueryResponseCareTeamOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseCareTeamOrganizationType(RedoxAbstractModel):
@@ -668,9 +668,9 @@ class VisitQueryResponseEncounterLocationIdentifier(RedoxAbstractModel):
 
 class VisitQueryResponseEncounterLocationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseEncounterLocationType(RedoxAbstractModel):
@@ -1108,7 +1108,7 @@ class VisitQueryResponseHeaderDocumentCustodian(RedoxAbstractModel):
     Identifiers: List["VisitQueryResponseHeaderDocumentCustodianIdentifier"] = Field(
         None
     )
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitQueryResponseHeaderDocumentCustodianTelecom"] = Field(None)
     Type: "VisitQueryResponseHeaderDocumentCustodianType" = Field(None)
 
@@ -1131,9 +1131,9 @@ class VisitQueryResponseHeaderDocumentCustodianIdentifier(RedoxAbstractModel):
 
 class VisitQueryResponseHeaderDocumentCustodianTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseHeaderDocumentCustodianType(RedoxAbstractModel):
@@ -1340,7 +1340,7 @@ class VisitQueryResponseHeaderPatientOrganization(RedoxAbstractModel):
     Identifiers: List["VisitQueryResponseHeaderPatientOrganizationIdentifier"] = Field(
         None
     )
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["VisitQueryResponseHeaderPatientOrganizationTelecom"] = Field(None)
     Type: "VisitQueryResponseHeaderPatientOrganizationType" = Field(None)
 
@@ -1363,9 +1363,9 @@ class VisitQueryResponseHeaderPatientOrganizationIdentifier(RedoxAbstractModel):
 
 class VisitQueryResponseHeaderPatientOrganizationTelecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseHeaderPatientOrganizationType(RedoxAbstractModel):
@@ -1402,8 +1402,8 @@ class VisitQueryResponseHealthConcern(RedoxAbstractModel):
     StartDate: Union[str, None] = Field(None)
     Status: Union[str, None] = Field(None)
     TargetSite: "VisitQueryResponseHealthConcernTargetSite" = Field(None)
-    Units: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    Units: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class VisitQueryResponseHealthConcernAltCode(RedoxAbstractModel):
@@ -2504,7 +2504,7 @@ class VisitQueryResponseResultProducerAddress(RedoxAbstractModel):
 
 class VisitQueryResponseResultSpecimen(RedoxAbstractModel):
 
-    CollectionDateTime: Union[None] = Field(None)
+    CollectionDateTime: Union[str, None] = Field(None)
     Identifiers: List[str] = Field(None)
     Source: "VisitQueryResponseResultSpecimenSource" = Field(None)
     TargetSite: "VisitQueryResponseResultSpecimenTargetSite" = Field(None)

--- a/pyredox/generic/types.py
+++ b/pyredox/generic/types.py
@@ -600,7 +600,7 @@ class Custodian(RedoxAbstractModel):
     FirstName: Union[str, None] = Field(None)
     Identifiers: List["Identifier"] = Field(None)
     LastName: Union[str, None] = Field(None)
-    Name: Union[None] = Field(None)
+    Name: Union[str, None] = Field(None)
     Telecom: List["Telecom"] = Field(None)
     Type: "Type" = Field(None)
 
@@ -959,8 +959,8 @@ class Guarantor(RedoxAbstractModel):
 
 class Header(RedoxAbstractModel):
 
-    DirectAddressFrom: Union[None] = Field(None)
-    DirectAddressTo: Union[None] = Field(None)
+    DirectAddressFrom: Union[str, None] = Field(None)
+    DirectAddressTo: Union[str, None] = Field(None)
     Document: "Document" = Field(None)
     PCP: "PCP" = Field(None)
     Patient: "Patient" = Field(None)
@@ -981,8 +981,8 @@ class HealthConcern(RedoxAbstractModel):
     StartDate: Union[str, None] = Field(None)
     Status: Union[str, None] = Field(None)
     TargetSite: "TargetSite" = Field(None)
-    Units: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    Units: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class HealthStatus(RedoxAbstractModel):
@@ -2174,7 +2174,7 @@ class SpecialtyDepartment(RedoxAbstractModel):
 class Specimen(RedoxAbstractModel):
 
     BodySite: Union[str, None] = Field(None)
-    CollectionDateTime: Union[None] = Field(None)
+    CollectionDateTime: Union[str, None] = Field(None)
     ID: Union[str, None] = Field(None)
     Identifiers: List[str] = Field(None)
     Source: Union["Source", str, None] = Field(None)
@@ -2347,9 +2347,9 @@ class TargetSite(RedoxAbstractModel):
 
 class Telecom(RedoxAbstractModel):
 
-    System: Union[None] = Field(None)
-    Use: Union[None] = Field(None)
-    Value: Union[None] = Field(None)
+    System: Union[str, None] = Field(None)
+    Use: Union[str, None] = Field(None)
+    Value: Union[str, None] = Field(None)
 
 
 class TobaccoUse(RedoxAbstractModel):
@@ -2436,7 +2436,7 @@ class UnsignedMedicationOrder(RedoxAbstractModel):
     Priority: Union[str, None] = Field(None)
     Product: "Product" = Field(None)
     Questions: List["Question"] = Field(None)
-    Route: Union[None] = Field(None)
+    Route: Union[str, None] = Field(None)
     StartDate: Union[str, None] = Field(None)
 
 

--- a/tests/fixtures/claim_payment.json
+++ b/tests/fixtures/claim_payment.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Claim",
     "EventType": "Payment",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/claim_paymentbatch.json
+++ b/tests/fixtures/claim_paymentbatch.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Claim",
     "EventType": "PaymentBatch",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/claim_submission.json
+++ b/tests/fixtures/claim_submission.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Claim",
     "EventType": "Submission",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/claim_submissionbatch.json
+++ b/tests/fixtures/claim_submissionbatch.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Claim",
     "EventType": "SubmissionBatch",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/clinicaldecisions_request.json
+++ b/tests/fixtures/clinicaldecisions_request.json
@@ -1,0 +1,194 @@
+{
+  "Meta": {
+    "DataModel": "Clinical Decisions",
+    "EventType": "Request",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "af394f14-b34a-464f-8d24-895f370af4c9",
+        "Name": "Redox EMR"
+      }
+    ],
+    "Logs": [
+      {
+        "ID": "d9f5d293-7110-461e-a875-3beb089e79f3",
+        "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    }
+  },
+  "Session": {
+    "Questions": [
+      {
+        "Question": {},
+        "Answer": {}
+      }
+    ]
+  },
+  "Patient": {
+    "Identifiers": [
+      {
+        "ID": "0000000001",
+        "IDType": "MR"
+      },
+      {
+        "ID": "e167267c-16c9-4fe3-96ae-9cff5703e90a",
+        "IDType": "EHRID"
+      },
+      {
+        "ID": "a1d4ee8aba494ca",
+        "IDType": "NIST"
+      }
+    ],
+    "Demographics": {
+      "FirstName": "Timothy",
+      "MiddleName": "Paul",
+      "LastName": "Bixby",
+      "DOB": "2008-01-06",
+      "SSN": "101-01-0001",
+      "Sex": "Male",
+      "Race": "White",
+      "MaritalStatus": "Single",
+      "PhoneNumber": {
+        "Home": "+18088675301"
+      },
+      "EmailAddresses": [],
+      "Language": "en",
+      "Citizenship": [],
+      "Address": {
+        "StreetAddress": "4762 Hickory Street",
+        "City": "Monroe",
+        "State": "WI",
+        "ZIP": "53566",
+        "County": "Green",
+        "Country": "US"
+      }
+    },
+    "Notes": []
+  },
+  "OrderingProvider": {
+    "ID": "4236464757",
+    "IDType": "NPI",
+    "FirstName": "John",
+    "LastName": "Slate",
+    "Credentials": [
+      "DO"
+    ],
+    "Address": {
+      "StreetAddress": "500 First St.",
+      "City": "Clayton",
+      "State": "MO",
+      "ZIP": "63105",
+      "County": "Saint Louis",
+      "Country": "USA"
+    },
+    "EmailAddresses": [],
+    "PhoneNumber": {
+      "Office": "+13145554321"
+    },
+    "Location": {}
+  },
+  "AuthorizingProvider": {
+    "ID": "4356789876",
+    "IDType": "NPI",
+    "FirstName": "Pat",
+    "LastName": "Granite",
+    "Credentials": [
+      "MD"
+    ],
+    "Address": {
+      "StreetAddress": "123 Main St.",
+      "City": "Madison",
+      "State": "WI",
+      "ZIP": "53703",
+      "County": "Dane",
+      "Country": "USA"
+    },
+    "EmailAddresses": [],
+    "PhoneNumber": {
+      "Office": "+16085551234"
+    },
+    "Location": {}
+  },
+  "UnsignedMedicationOrders": [
+    {
+      "Identifiers": [
+        {
+          "ID": "384209384094849",
+          "IDType": "EHR"
+        }
+      ],
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "Name": "Ondansetron 4 Mg Po Tbdp"
+      },
+      "Priority": "Stat",
+      "Dose": {
+        "Quantity": 4,
+        "Units": "mg"
+      },
+      "Mode": "IP",
+      "Route": "Oral",
+      "StartDate": "2005-05-01T04:00:00.000Z",
+      "EndDate": "2011-02-27T05:00:00.000Z",
+      "MixtureComponents": [
+        {
+          "Dose": {}
+        }
+      ],
+      "Questions": [
+        {
+          "Question": {
+            "Description": "Why is this medication being ordered?"
+          },
+          "Answer": {
+            "Description": "To prevent nausea after chemotherapy."
+          }
+        }
+      ],
+      "Notes": []
+    }
+  ],
+  "UnsignedProcedureOrders": [
+    {
+      "Code": "76700",
+      "Codeset": "CPT",
+      "Identifiers": [
+        {
+          "ID": "329308430984409",
+          "IDType": 4444
+        }
+      ],
+      "ScheduledDate": "2005-07-02T04:00:00:000Z",
+      "Mode": "IP",
+      "BodySite": {},
+      "StartDate": "2005-05-01T04:00:00.000Z",
+      "EndDate": "2011-02-27T05:00:00.000Z",
+      "Questions": [
+        {
+          "Question": {
+            "Description": "Why is this ultrasound being ordered?"
+          },
+          "Answer": {
+            "Description": "The patient swallowed a foreign body."
+          }
+        }
+      ],
+      "Notes": []
+    }
+  ]
+}

--- a/tests/fixtures/clinicaldecisions_response.json
+++ b/tests/fixtures/clinicaldecisions_response.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Decisions",
     "EventType": "Response",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/clinicalsummary_documentget.json
+++ b/tests/fixtures/clinicalsummary_documentget.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "DocumentGet",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/clinicalsummary_documentgetresponse.json
+++ b/tests/fixtures/clinicalsummary_documentgetresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "DocumentGetResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/clinicalsummary_documentquery.json
+++ b/tests/fixtures/clinicalsummary_documentquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "DocumentQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/clinicalsummary_documentqueryresponse.json
+++ b/tests/fixtures/clinicalsummary_documentqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "DocumentQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -71,7 +71,7 @@
       "Visit": {
         "ID": "12345678"
       },
-      "DateTime": "2022-08-01T18:38:57.828Z",
+      "DateTime": "2022-08-03T18:06:44.296Z",
       "ID": "123",
       "Locale": "US",
       "Title": "Discharge Summary",

--- a/tests/fixtures/clinicalsummary_patientpush.json
+++ b/tests/fixtures/clinicalsummary_patientpush.json
@@ -1,0 +1,1532 @@
+{
+  "Meta": {
+    "DataModel": "Clinical Summary",
+    "EventType": "PatientPush",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "ef9e7448-7f65-4432-aa96-059647e9b358",
+        "Name": "Patient Push Endpoint"
+      }
+    ],
+    "Logs": [
+      {
+        "ID": "d9f5d293-7110-461e-a875-3beb089e79f3",
+        "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    }
+  },
+  "Header": {
+    "DirectAddressFrom": "[email\u00a0protected]",
+    "DirectAddressTo": "[email\u00a0protected]",
+    "Document": {
+      "Author": {
+        "ID": "4356789876",
+        "IDType": "2.16.840.1.113883.4.6",
+        "FirstName": "Pat",
+        "LastName": "Granite",
+        "Credentials": [
+          "MD"
+        ],
+        "Address": {
+          "StreetAddress": "123 Main St.",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+16085551234"
+        },
+        "Location": {}
+      },
+      "ID": "75cb4ad4-e5f9-4cd3-8750-eb5050521e0d",
+      "Locale": "US",
+      "Title": "Community Health and Hospitals: Health Summary",
+      "DateTime": "2012-09-12T00:00:00.000Z",
+      "Type": "Summarization of Episode Note",
+      "TypeCode": {
+        "Code": "34133-9",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Summarization of Episode Note"
+      },
+      "Confidentiality": {
+        "Code": "N",
+        "CodeSystem": "2.16.840.1.113883.5.25",
+        "CodeSystemName": "Confidentiality",
+        "Name": "normal"
+      },
+      "Custodian": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      },
+      "Visit": {
+        "Type": {
+          "AltCodes": []
+        },
+        "Location": {},
+        "DischargeDisposition": {
+          "AltCodes": []
+        }
+      }
+    },
+    "Patient": {
+      "Identifiers": [
+        {
+          "ID": "1234",
+          "IDType": "2.16.840.1.113883.4.6"
+        }
+      ],
+      "Demographics": {
+        "FirstName": "Myra",
+        "LastName": "Jones",
+        "DOB": "1947-05-01",
+        "SSN": "123-101-1234",
+        "Sex": "Female",
+        "Address": {
+          "StreetAddress": "1357 Amber Drive",
+          "City": "Beaverton",
+          "State": "OR",
+          "Country": "US",
+          "ZIP": "97006"
+        },
+        "PhoneNumber": {
+          "Home": "+18162766909"
+        },
+        "EmailAddresses": [
+          {
+            "Address": "[email\u00a0protected]"
+          }
+        ],
+        "Race": "White",
+        "RaceCodes": [
+          {
+            "Code": "2106-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "White"
+          },
+          {
+            "Code": "2112-1",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "German"
+          }
+        ],
+        "Ethnicity": "Hispanic or Latino",
+        "EthnicGroupCodes": [
+          {
+            "Code": "2135-2",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Hispanic or Latino"
+          },
+          {
+            "Code": "2149-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Mexican American"
+          }
+        ],
+        "Religion": "Christian (non-Catholic, non-specific)",
+        "MaritalStatus": "Married",
+        "IsDeceased": false
+      },
+      "Organization": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      }
+    },
+    "PCP": {
+      "Credentials": [],
+      "Address": {},
+      "EmailAddresses": [],
+      "PhoneNumber": {},
+      "Location": {}
+    }
+  },
+  "AdvanceDirectivesText": "<table width=\"100%\"><thead><tr><th>Directive</th><th>Description</th><th>Verification</th><th>Supporting Document(s)</th></tr></thead><tbody><tr><td>Resuscitation status</td><td ID=\"AD1\">Do not resuscitate</td><td>Dr. Robert Dolin, Nov 07, 1999</td><td><linkHtml href=\"AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf\">Advance directive</linkHtml></td></tr></tbody></table>",
+  "AdvanceDirectives": [
+    {
+      "Type": {
+        "Code": "304251008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resuscitation",
+        "AltCodes": []
+      },
+      "Code": "304253006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Do not resuscitate",
+      "AltCodes": [],
+      "StartDate": "2011-02-13T05:00:00.000Z",
+      "ExternalReference": "AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf",
+      "VerifiedBy": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr."
+        }
+      ],
+      "Custodians": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr.",
+          "Address": {
+            "StreetAddress": "21 North Ave.",
+            "City": "Burlington",
+            "State": "MA",
+            "Country": "USA",
+            "ZIP": "02368"
+          }
+        }
+      ]
+    }
+  ],
+  "AllergyText": "<table width=\"100%\"><thead><tr><th>Substance</th><th>Reaction</th><th>Severity</th><th>Status</th></tr></thead><tbody><tr><td>Penicillin G benzathine</td><td ID=\"reaction1\">Hives</td><td ID=\"severity1\">Moderate to severe</td><td>Inactive</td></tr><tr><td>Codeine</td><td ID=\"reaction2\">Shortness of Breath</td><td ID=\"severity2\">Moderate</td><td>Active</td></tr><tr><td>Aspirin</td><td ID=\"reaction3\">Hives</td><td ID=\"severity3\">Mild to moderate</td><td>Active</td></tr></tbody></table>",
+  "Allergies": [
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "7982",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Penicillin G benzathine",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "28926001",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Rash",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "255604002",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild"
+          }
+        },
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITH",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "High criticality"
+      },
+      "Status": {
+        "Code": "73425007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Inactive"
+      },
+      "Comments": [
+        {
+          "Text": "Noted when patient took penicillin for ear infection."
+        }
+      ]
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "2670",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Codeine",
+        "AltCodes": [
+          {
+            "Code": "11QV9BS0CB",
+            "CodeSystem": "2.16.840.1.113883.4.9",
+            "CodeSystemName": "UNII",
+            "Name": "Codeine"
+          }
+        ]
+      },
+      "Reaction": [
+        {
+          "Code": "267036007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Shortness of Breath",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITL",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Low criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "1191",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Aspirin",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "371923003",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild to moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "371923003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Mild to moderate"
+      },
+      "Criticality": {
+        "Code": "CRITU",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Unable to assess criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    }
+  ],
+  "CareTeams": [],
+  "EncountersText": "<table width=\"100%\"><thead><tr><th>Encounter</th><th>Performer</th><th>Location</th><th>Date</th></tr></thead><tbody><tr ID=\"Encounter1\"><td>&#xD;\nPnuemonia</td><td>Dr Henry Seven</td><td>Community Health and Hospitals</td><td>20120806</td></tr></tbody></table>",
+  "Encounters": [
+    {
+      "Identifiers": [
+        {
+          "ID": "2376492",
+          "IDType": "URMC Epic CSN"
+        },
+        {
+          "ID": "8237334",
+          "IDType": "1.35.829.5.238422.9.10"
+        }
+      ],
+      "Type": {
+        "Code": "99222",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "InPatient Admission",
+        "AltCodes": []
+      },
+      "DateTime": "2012-08-06T04:00:00.000Z",
+      "Providers": [
+        {
+          "Credentials": [],
+          "Address": {},
+          "EmailAddresses": [],
+          "PhoneNumber": {},
+          "Location": {},
+          "Role": {
+            "Code": "59058001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "General Physician",
+            "AltCodes": []
+          }
+        }
+      ],
+      "Locations": [
+        {
+          "Identifiers": [],
+          "Telecom": [],
+          "Address": {
+            "StreetAddress": "1002 Healthcare Dr",
+            "City": "Portland",
+            "State": "OR",
+            "Country": "US",
+            "ZIP": "97266"
+          },
+          "Type": {
+            "Code": "1160-1",
+            "CodeSystem": "2.16.840.1.113883.6.259",
+            "CodeSystemName": "HealthcareServiceLocation",
+            "Name": "Urgent Care Center",
+            "AltCodes": []
+          },
+          "Name": "Community Health and Hospitals"
+        }
+      ],
+      "Diagnosis": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "ReasonForVisit": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "DischargeDisposition": {
+        "AltCodes": []
+      }
+    }
+  ],
+  "FamilyHistoryText": "<paragraph>Father (deceased)</paragraph><table width=\"100%\"><thead><tr><th>Diagnosis</th><th>Age At Onset</th></tr></thead><tbody><tr><td>Myocardial Infarction (cause of death)</td><td>57</td></tr><tr><td>Diabetes</td><td>40</td></tr></tbody></table>",
+  "FamilyHistory": [
+    {
+      "Relation": {
+        "Code": "FTH",
+        "CodeSystem": "2.16.840.1.113883.5.111",
+        "CodeSystemName": "HL7 FamilyMember",
+        "Name": "Father",
+        "Demographics": {
+          "Sex": "Male",
+          "DOB": "1912-01-01"
+        },
+        "IsDeceased": true
+      },
+      "Problems": [
+        {
+          "Code": "22298006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Myocardial infarction",
+          "AltCodes": [],
+          "Type": {
+            "Code": "55607006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Problem"
+          },
+          "AgeAtOnset": "57"
+        },
+        {
+          "Code": "46635009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Diabetes mellitus type 1",
+          "AltCodes": [],
+          "Type": {
+            "Code": "64572001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Condition"
+          },
+          "DateTime": "1994-01-01T05:00:00.000Z",
+          "AgeAtOnset": "40"
+        }
+      ]
+    }
+  ],
+  "FunctionalStatusText": "<table><thead><tr><th>Assessment</th><th>Date</th><th>Results</th><th>Comments</th></tr></thead><tbody><tr ID=\"FS_Narrative1\"><td ID=\"FS_Type\">Functional Status</td><td>August 15 2012, 5:32pm</td><td ID=\"FS_Finding1\">Dependence on walking stick</td><td></td></tr><tr ID=\"FS_Narrative2\"><td ID=\"FS_Type\">Functional Status</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent with dressing</td><td></td></tr><tr ID=\"FS_Narrative3\"><td ID=\"FS_Type\">Transferring</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent</td><td></td></tr><tr ID=\"FS_Narrative4\"><td ID=\"FS_Type\">Hearing</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Impaired</td><td></td></tr></tbody></table>",
+  "FunctionalStatus": {
+    "Observations": [
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2012-08-15",
+        "CodedValue": {
+          "Code": "105504002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Dependence on walking stick",
+          "AltCodes": []
+        },
+        "Value": "Dependence on walking stick",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "129035000",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent with dressing",
+          "AltCodes": []
+        },
+        "Value": "Independent with dressing",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "46482-6",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Transferring",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "371153006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent",
+          "AltCodes": []
+        },
+        "Value": "Independent",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "47078008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Hearing",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "260379002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Impaired",
+          "AltCodes": []
+        },
+        "Value": "Impaired",
+        "ReferenceRange": {},
+        "Comments": []
+      }
+    ],
+    "Supplies": [
+      {
+        "Code": "14106009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cardiac Pacemaker",
+        "AltCodes": [],
+        "Status": "completed",
+        "DateTime": "2013-07-03"
+      }
+    ]
+  },
+  "GoalsText": "<paragraph ID=\"Goals\">Patient is targeting a pulse oximetry of 92%</paragraph>",
+  "Goals": [
+    {
+      "Code": "59408-5",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Oxygen saturation in Arterial blood by Pulse oximetry",
+      "AltCodes": [],
+      "DateTime": "2012-12-31T23:59:59.999Z",
+      "CodedValue": {
+        "AltCodes": []
+      },
+      "Value": "92",
+      "Units": "%",
+      "StartDate": "2013-09-02",
+      "EndDate": "2013-09-02",
+      "Priority": {
+        "Code": "394849002",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "High priority"
+      },
+      "AchievementStatus": {
+        "Name": "On track"
+      },
+      "Milestones": [],
+      "Comments": []
+    }
+  ],
+  "HealthConcernsText": "<table><thead><tr><th>Health Concern</th><th>Date</th><th>Related Problem</th></tr></thead><tbody><tr ID=\"Concern1\"><td ID=\"Concern1Issue1\">Concerned about being contagious and infecting roommate.</td><td>Concern from 03/02/2014</td><td>Community Acquired Pneumonia</td></tr></tbody></table>",
+  "HealthConcerns": [
+    {
+      "Category": {
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "Code": "385093006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Community Acquired Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "TargetSite": {
+        "AltCodes": []
+      },
+      "Status": "active",
+      "Comments": []
+    }
+  ],
+  "ImmunizationText": "<table width=\"100%\"><thead><tr><th>Vaccine</th><th>Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"immun2\">Influenza virus vaccine, IM</td><td>May 2012</td><td>Completed</td></tr><tr><td ID=\"immun4\">Tetanus and diphtheria toxoids, IM</td><td>Apr 2012</td><td>Completed</td></tr></tbody></table>",
+  "Immunizations": [
+    {
+      "DateTime": "2012-05-10T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "88",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Influenza virus vaccine",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    },
+    {
+      "DateTime": "2012-04-01T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "103",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Tetanus and diphtheria toxoids - preservative free",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    }
+  ],
+  "Insurances": [
+    {
+      "Plan": {
+        "ID": "31572",
+        "IDType": "2.16.840.1.113883.4.642.3.520",
+        "Name": "HMO Deductible Plan"
+      },
+      "Company": {
+        "ID": "60054",
+        "Name": "aetna (60054 0131)",
+        "Address": {
+          "StreetAddress": "PO Box 14080",
+          "City": "Lexington",
+          "State": "KY",
+          "ZIP": "40512-4079",
+          "County": "Fayette",
+          "Country": "US"
+        },
+        "PhoneNumber": "+18089541123"
+      },
+      "GroupNumber": "847025-024-0009",
+      "GroupName": "Accelerator Labs",
+      "EffectiveDate": "2015-01-01",
+      "ExpirationDate": "2020-12-31",
+      "PolicyNumber": "9140860055",
+      "Insured": {
+        "Identifiers": [],
+        "Address": {}
+      }
+    }
+  ],
+  "MedicalHistoryText": "<table><colgroup><col width=\"38%\"/><col width=\"12%\"/><col width=\"50%\"/></colgroup><thead><tr><th>Medical History</th><th>Date</th><th>Comments</th></tr></thead><tbody><tr ID=\"medhist54\"><td>Unspecified essential hypertension</td><td>1985</td><td>Diagnosed age 56. Initially treated with sodium restriction, diet, exercise. Diuretics started ~1986, taken sporadically since that time. Patient admits to poor compliance with med regimen. </td></tr><tr ID=\"medhist55\"><td>Variants of migraine, not elsewhere classified, without mention of intractable migraine without mention of status migrainosus</td><td>1989</td><td>Cluster headaches for approximately 5 yr period, occurring 2-3 X yearly. None since 1997.</td></tr><tr ID=\"medhist56\"><td>Acquired hypothyroidism</td><td>1998</td><td/></tr></tbody></table>",
+  "MedicalEquipmentText": "<table width=\"100%\"><thead><tr><th>Supply/Device</th><th>Date Supplied</th></tr></thead><tbody><tr><td>Automatic implantable cardioverter/defibrillator</td><td>Nov 1999</td></tr><tr><td>Total hip replacement prosthesis</td><td>1998</td></tr><tr><td>Wheelchair</td><td>1999</td></tr></tbody></table>",
+  "MedicalEquipment": [
+    {
+      "Status": "completed",
+      "StartDate": "1999-11-01T05:00:00.000Z",
+      "Quantity": "2",
+      "Comments": [],
+      "Product": {
+        "Code": "72506001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Automatic implantable cardioverter/defibrillator",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1998-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "304120007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Total hip replacement prosthesis",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1999-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "58938008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Wheelchair",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    }
+  ],
+  "MedicationsText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Directions</th><th>Start Date</th><th>Status</th><th>Indications</th><th>Fill Instructions</th></tr></thead><tbody><tr><td ID=\"Med1\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td><td>Pneumonia (233604007 SNOMED CT)</td><td ID=\"FillIns\">Generic Substitition Allowed</td></tr></tbody></table>",
+  "Medications": [
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      },
+      "Indications": [],
+      "SupplyOrder": {}
+    },
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "IsPRN": true,
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      },
+      "Indications": [
+        {
+          "Code": "422587007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Nausea",
+          "AltCodes": []
+        }
+      ],
+      "SupplyOrder": {}
+    }
+  ],
+  "NoteSections": [
+    {
+      "Code": "11504-8",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Surgical operation note",
+      "AltCodes": [],
+      "Title": "OR Notes",
+      "Text": "<list> <item> <caption>OR PostOp - Pat Granite, MD - 10/20/2021  4:55 PM CDT</caption> <content ID=\"Note37\">Example note. <br />Signed by Pat Granite on 10/20/2021</content> </item> </list>",
+      "Notes": [
+        {
+          "Code": "34109-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "OR PostOp",
+          "AltCodes": [
+            {
+              "Code": "34875-5",
+              "CodeSystem": "2.16.840.1.113883.6.1",
+              "CodeSystemName": "LOINC",
+              "Name": "OR PostOp"
+            }
+          ],
+          "ContentType": "Plain Text",
+          "FileContents": "<content ID=\"Note37\">Example note. <br />Signed by Pat Granite on 10/20/2021</content>",
+          "DateTime": "2021-10-20T21:55:00.000Z",
+          "Status": "completed",
+          "Encounter": {
+            "Identifiers": [
+              {
+                "ID": "10000048107",
+                "IDType": "1.2.840.114350.1.13.3440.1.7.3.698084.8"
+              }
+            ],
+            "Type": {
+              "Code": "AMB",
+              "CodeSystem": "2.16.840.1.113883.5.4",
+              "AltCodes": []
+            },
+            "DateTime": "2021-10-20T16:55:00.000Z"
+          }
+        }
+      ]
+    }
+  ],
+  "PlanOfCareText": "<table width=\"100%\"><thead><tr><th>Planned Activity</th><th>Planned Date</th></tr></thead><tbody><tr><td>Consultation with Dr George Potomac for Asthma</td><td>20120820</td></tr><tr><td>Chest X-ray</td><td>20120826</td></tr><tr><td>Sputum Culture</td><td>20120820</td></tr></tbody></table>",
+  "PlanOfCare": {
+    "Orders": [
+      {
+        "Code": "624-7",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "Name": "Sputum Culture",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-26T05:00:00.000Z"
+      }
+    ],
+    "Encounters": [
+      {
+        "Code": "99241",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "Office consultation - 15 minutes",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": "Intent",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "MedicationAdministration": [
+      {
+        "Status": "Intent",
+        "Dose": {
+          "Quantity": "81",
+          "Units": "milliGRAM(s)"
+        },
+        "Rate": {},
+        "Route": {
+          "Code": "C38288",
+          "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          "CodeSystemName": "NCI Thesaurus",
+          "Name": "ORAL",
+          "AltCodes": []
+        },
+        "StartDate": "2012-10-02T05:00:00.000Z",
+        "EndDate": "2012-10-31T04:59:00.000Z",
+        "Frequency": {},
+        "Product": {
+          "Code": "1191",
+          "CodeSystem": "2.16.840.1.113883.6.88",
+          "CodeSystemName": "RxNorm",
+          "Name": "aspirin",
+          "AltCodes": []
+        }
+      }
+    ],
+    "Supplies": [],
+    "Services": [
+      {
+        "Code": "427519008",
+        "CodeSystem": "2.16.840.1.113883.11.20.9.34",
+        "CodeSystemName": "patientEducationType",
+        "Name": "Caregiver",
+        "AltCodes": [],
+        "Status": "Intent"
+      }
+    ]
+  },
+  "ProblemsText": "<list><item ID=\"problem1\">Pneumonia : Status - Resolved</item><item ID=\"problem2\">Asthma : Status - Active</item></list>",
+  "Problems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "233604007",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        },
+        {
+          "Code": "486",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    },
+    {
+      "StartDate": "2007-10-17T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "195967001",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Asthma",
+      "AltCodes": [
+        {
+          "Code": "J45.909",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Asthma"
+        },
+        {
+          "Code": "493.90",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Asthma"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ProceduresText": "<table width=\"100%\"><thead><tr><th>Procedure</th><th>Date</th></tr></thead><tbody><tr><td ID=\"Proc2\">Chest X-Ray</td><td>8/7/2012</td></tr></tbody></table>",
+  "Procedures": {
+    "Observations": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake observation",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "active",
+        "TargetSite": {
+          "Code": "302539009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire hand (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "completed",
+        "TargetSite": {
+          "Code": "181608004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire chest wall (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Services": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake action",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "aborted",
+        "Comments": []
+      }
+    ]
+  },
+  "ResolvedProblemsText": "<list><item ID=\"problem1\">Tobacco abuse : Status - Resolved</item></list>",
+  "ResolvedProblems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "110483000",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Tobacco abuse",
+      "AltCodes": [
+        {
+          "Code": "Z72.0",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "305.1",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "55885",
+          "CodeSystem": "2.16.840.1.113883.3.247.1.1",
+          "CodeSystemName": "Intelligent Medical Objects ProblemIT",
+          "Name": "Tobacco abuse"
+        }
+      ],
+      "Category": {
+        "Code": "64572001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Tobacco abuse",
+        "AltCodes": [
+          {
+            "Code": "75323-6",
+            "CodeSystem": "2.16.840.1.113883.6.1",
+            "CodeSystemName": "LOINC",
+            "Name": "Tobacco abuse"
+          }
+        ]
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": []
+    }
+  ],
+  "ResultText": "<table><tbody><tr><td colspan=\"2\">LABORATORY INFORMATION</td></tr><tr><td colspan=\"2\">Chemistries and drug levels</td></tr><tr><td ID=\"result1\">HGB (M 13-18 g/dl; F 12-16 g/dl)</td><td>13.2</td></tr><tr><td ID=\"result2\">WBC (4.3-10.8 10+3/ul)</td><td>6.7</td></tr><tr><td ID=\"result3\">PLT (135-145 meq/l)</td><td>123 (L)</td></tr></tbody></table>",
+  "Results": [
+    {
+      "Code": "43789009",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "CBC WO DIFFERENTIAL",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "Final",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "CollectionDateTime": "2012-08-10T14:00:00.000Z",
+        "Identifiers": [
+          "1.2.840.113840.5^BL-201201-01"
+        ],
+        "Source": {
+          "Code": "420135007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Blood, whole"
+        },
+        "TargetSite": {
+          "Code": "LA",
+          "CodeSystem": "2.16.840.1.113883.18.81",
+          "CodeSystemName": "Body Site",
+          "Name": "Left Arm"
+        }
+      },
+      "Observations": [
+        {
+          "Code": "30313-1",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "HGB",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "10.2",
+          "ValueType": "PhysicalQuantity",
+          "Units": "g/dl",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "33765-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "WBC",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "12.3",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "26515-7",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "PLT",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Low",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "123",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "Code": "624-7",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Sputum Culture",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "In Progress",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "Identifiers": [],
+        "Source": {},
+        "TargetSite": {}
+      },
+      "Observations": [
+        {
+          "Code": "86243-3",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Color of Sputum",
+          "AltCodes": [],
+          "Status": "Final",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "Code": "54662009",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Green",
+            "AltCodes": []
+          },
+          "Value": "Green",
+          "ValueType": "Code",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    }
+  ],
+  "SocialHistoryText": "<table width=\"100%\"><thead><tr><th>Social History Element</th><th>Description</th><th>Effective Dates</th></tr></thead><tbody><tr><td ID=\"soc1\">smoking</td><td>Former Smoker (1 pack per day</td><td>20050501 to 20110227</td></tr><tr><td ID=\"soc2\">smoking</td><td>Current Everyday Smoker 2 packs per day</td><td>20110227 - today</td></tr></tbody></table>",
+  "SocialHistory": {
+    "Observations": [
+      {
+        "Code": "160573003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Alcohol Consumption",
+        "AltCodes": [],
+        "Value": {
+          "AltCodes": []
+        },
+        "ValueText": "None",
+        "StartDate": "1990-05-01T04:00:00.000Z",
+        "Comments": []
+      }
+    ],
+    "Pregnancy": [],
+    "TobaccoUse": [
+      {
+        "Code": "8517006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Former smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": true,
+        "StartDate": "2015-06-03T09:35:00.000Z",
+        "Comments": []
+      },
+      {
+        "Code": "65568007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cigarette smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": false,
+        "StartDate": "2005-05-01",
+        "EndDate": "2008-09-01",
+        "Comments": []
+      }
+    ]
+  },
+  "VitalSignsText": "<table width=\"100%\"><thead><tr><th align=\"right\">Date / Time: </th><th>Nov 1, 2011</th><th>August 6, 2012</th></tr></thead><tbody><tr><th align=\"left\">Height</th><td ID=\"vit1\">69 inches</td><td ID=\"vit2\">69 inches</td></tr><tr><th align=\"left\">Weight</th><td ID=\"vit3\">189 lbs</td><td ID=\"vit4\">194 lbs</td></tr><tr><th align=\"left\">Blood Pressure</th><td ID=\"vit5\">132/86 mmHg</td><td ID=\"vit6\">145/88 mmHg</td></tr></tbody></table>",
+  "VitalSigns": [
+    {
+      "DateTime": "1999-11-14T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "86",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "132",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "DateTime": "2000-04-07T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "88",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "145",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/clinicalsummary_patientquery.json
+++ b/tests/fixtures/clinicalsummary_patientquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "PatientQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/clinicalsummary_patientqueryresponse.json
+++ b/tests/fixtures/clinicalsummary_patientqueryresponse.json
@@ -1,0 +1,1475 @@
+{
+  "Meta": {
+    "DataModel": "Clinical Summary",
+    "EventType": "PatientQueryResponse",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "ef9e7448-7f65-4432-aa96-059647e9b358",
+        "Name": "Patient Query Endpoint"
+      }
+    ],
+    "Logs": [
+      {
+        "ID": "d9f5d293-7110-461e-a875-3beb089e79f3",
+        "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    }
+  },
+  "Header": {
+    "Document": {
+      "Author": {
+        "ID": "4356789876",
+        "IDType": "2.16.840.1.113883.4.6",
+        "FirstName": "Pat",
+        "LastName": "Granite",
+        "Credentials": [
+          "MD"
+        ],
+        "Address": {
+          "StreetAddress": "123 Main St.",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+16085551234"
+        },
+        "Location": {}
+      },
+      "ID": "75cb4ad4-e5f9-4cd3-8750-eb5050521e0d",
+      "Locale": "US",
+      "Title": "Community Health and Hospitals: Health Summary",
+      "DateTime": "2012-09-12T00:00:00.000Z",
+      "Type": "Summarization of Episode Note",
+      "TypeCode": {
+        "Code": "34133-9",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Summarization of Episode Note"
+      },
+      "Confidentiality": {
+        "Code": "N",
+        "CodeSystem": "2.16.840.1.113883.5.25",
+        "CodeSystemName": "Confidentiality",
+        "Name": "normal"
+      },
+      "Custodian": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      }
+    },
+    "Patient": {
+      "Identifiers": [
+        {
+          "ID": "1234",
+          "IDType": "2.16.840.1.113883.4.6"
+        }
+      ],
+      "Demographics": {
+        "FirstName": "Myra",
+        "LastName": "Jones",
+        "DOB": "1947-05-01",
+        "SSN": "123-101-1234",
+        "Sex": "Female",
+        "Address": {
+          "StreetAddress": "1357 Amber Drive",
+          "City": "Beaverton",
+          "State": "OR",
+          "Country": "US",
+          "ZIP": "97006"
+        },
+        "PhoneNumber": {
+          "Home": "+18162766909"
+        },
+        "EmailAddresses": [
+          {
+            "Address": "[email\u00a0protected]"
+          }
+        ],
+        "Race": "White",
+        "RaceCodes": [
+          {
+            "Code": "2106-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "White"
+          },
+          {
+            "Code": "2112-1",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "German"
+          }
+        ],
+        "Ethnicity": "Hispanic or Latino",
+        "EthnicGroupCodes": [
+          {
+            "Code": "2135-2",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Hispanic or Latino"
+          },
+          {
+            "Code": "2149-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Mexican American"
+          }
+        ],
+        "Religion": "Christian (non-Catholic, non-specific)",
+        "MaritalStatus": "Married",
+        "IsDeceased": false
+      },
+      "Organization": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      }
+    },
+    "PCP": {
+      "Credentials": [],
+      "Address": {},
+      "EmailAddresses": [],
+      "PhoneNumber": {},
+      "Location": {}
+    }
+  },
+  "AdvanceDirectivesText": "<table width=\"100%\"><thead><tr><th>Directive</th><th>Description</th><th>Verification</th><th>Supporting Document(s)</th></tr></thead><tbody><tr><td>Resuscitation status</td><td ID=\"AD1\">Do not resuscitate</td><td>Dr. Robert Dolin, Nov 07, 1999</td><td><linkHtml href=\"AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf\">Advance directive</linkHtml></td></tr></tbody></table>",
+  "AdvanceDirectives": [
+    {
+      "Type": {
+        "Code": "304251008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resuscitation",
+        "AltCodes": []
+      },
+      "Code": "304253006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Do not resuscitate",
+      "AltCodes": [],
+      "StartDate": "2011-02-13T05:00:00.000Z",
+      "ExternalReference": "AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf",
+      "VerifiedBy": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr."
+        }
+      ],
+      "Custodians": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr.",
+          "Address": {
+            "StreetAddress": "21 North Ave.",
+            "City": "Burlington",
+            "State": "MA",
+            "Country": "USA",
+            "ZIP": "02368"
+          }
+        }
+      ]
+    }
+  ],
+  "AllergyText": "<table width=\"100%\"><thead><tr><th>Substance</th><th>Reaction</th><th>Severity</th><th>Status</th></tr></thead><tbody><tr><td>Penicillin G benzathine</td><td ID=\"reaction1\">Hives</td><td ID=\"severity1\">Moderate to severe</td><td>Inactive</td></tr><tr><td>Codeine</td><td ID=\"reaction2\">Shortness of Breath</td><td ID=\"severity2\">Moderate</td><td>Active</td></tr><tr><td>Aspirin</td><td ID=\"reaction3\">Hives</td><td ID=\"severity3\">Mild to moderate</td><td>Active</td></tr></tbody></table>",
+  "Allergies": [
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "7982",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Penicillin G benzathine",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "28926001",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Rash",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "255604002",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild"
+          }
+        },
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITH",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "High criticality"
+      },
+      "Status": {
+        "Code": "73425007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Inactive"
+      },
+      "Comments": [
+        {
+          "Text": "Noted when patient took penicillin for ear infection."
+        }
+      ]
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "2670",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Codeine",
+        "AltCodes": [
+          {
+            "Code": "11QV9BS0CB",
+            "CodeSystem": "2.16.840.1.113883.4.9",
+            "CodeSystemName": "UNII",
+            "Name": "Codeine"
+          }
+        ]
+      },
+      "Reaction": [
+        {
+          "Code": "267036007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Shortness of Breath",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITL",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Low criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "1191",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Aspirin",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "371923003",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild to moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "371923003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Mild to moderate"
+      },
+      "Criticality": {
+        "Code": "CRITU",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Unable to assess criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    }
+  ],
+  "CareTeams": [],
+  "EncountersText": "<table width=\"100%\"><thead><tr><th>Encounter</th><th>Performer</th><th>Location</th><th>Date</th></tr></thead><tbody><tr ID=\"Encounter1\"><td>&#xD;\nPnuemonia</td><td>Dr Henry Seven</td><td>Community Health and Hospitals</td><td>20120806</td></tr></tbody></table>",
+  "Encounters": [
+    {
+      "Identifiers": [
+        {
+          "ID": "2376492",
+          "IDType": "URMC Epic CSN"
+        },
+        {
+          "ID": "8237334",
+          "IDType": "1.35.829.5.238422.9.10"
+        }
+      ],
+      "Type": {
+        "Code": "99222",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "InPatient Admission",
+        "AltCodes": []
+      },
+      "DateTime": "2012-08-06T04:00:00.000Z",
+      "Providers": [
+        {
+          "Credentials": [],
+          "Address": {},
+          "EmailAddresses": [],
+          "PhoneNumber": {},
+          "Location": {},
+          "Role": {
+            "Code": "59058001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "General Physician",
+            "AltCodes": []
+          }
+        }
+      ],
+      "Locations": [
+        {
+          "Identifiers": [],
+          "Telecom": [],
+          "Address": {
+            "StreetAddress": "1002 Healthcare Dr",
+            "City": "Portland",
+            "State": "OR",
+            "Country": "US",
+            "ZIP": "97266"
+          },
+          "Type": {
+            "Code": "1160-1",
+            "CodeSystem": "2.16.840.1.113883.6.259",
+            "CodeSystemName": "HealthcareServiceLocation",
+            "Name": "Urgent Care Center",
+            "AltCodes": []
+          },
+          "Name": "Community Health and Hospitals"
+        }
+      ],
+      "Diagnosis": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "ReasonForVisit": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "DischargeDisposition": {
+        "AltCodes": []
+      }
+    }
+  ],
+  "FamilyHistoryText": "<paragraph>Father (deceased)</paragraph><table width=\"100%\"><thead><tr><th>Diagnosis</th><th>Age At Onset</th></tr></thead><tbody><tr><td>Myocardial Infarction (cause of death)</td><td>57</td></tr><tr><td>Diabetes</td><td>40</td></tr></tbody></table>",
+  "FamilyHistory": [
+    {
+      "Relation": {
+        "Code": "FTH",
+        "CodeSystem": "2.16.840.1.113883.5.111",
+        "CodeSystemName": "HL7 FamilyMember",
+        "Name": "Father",
+        "Demographics": {
+          "Sex": "Male",
+          "DOB": "1912-01-01"
+        },
+        "IsDeceased": true
+      },
+      "Problems": [
+        {
+          "Code": "22298006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Myocardial infarction",
+          "AltCodes": [],
+          "Type": {
+            "Code": "55607006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Problem"
+          },
+          "AgeAtOnset": "57"
+        },
+        {
+          "Code": "46635009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Diabetes mellitus type 1",
+          "AltCodes": [],
+          "Type": {
+            "Code": "64572001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Condition"
+          },
+          "DateTime": "1994-01-01T05:00:00.000Z",
+          "AgeAtOnset": "40"
+        }
+      ]
+    }
+  ],
+  "FunctionalStatusText": "<table><thead><tr><th>Assessment</th><th>Date</th><th>Results</th><th>Comments</th></tr></thead><tbody><tr ID=\"FS_Narrative1\"><td ID=\"FS_Type\">Functional Status</td><td>August 15 2012, 5:32pm</td><td ID=\"FS_Finding1\">Dependence on walking stick</td><td></td></tr><tr ID=\"FS_Narrative2\"><td ID=\"FS_Type\">Functional Status</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent with dressing</td><td></td></tr><tr ID=\"FS_Narrative3\"><td ID=\"FS_Type\">Transferring</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent</td><td></td></tr><tr ID=\"FS_Narrative4\"><td ID=\"FS_Type\">Hearing</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Impaired</td><td></td></tr></tbody></table>",
+  "FunctionalStatus": {
+    "Observations": [
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2012-08-15",
+        "CodedValue": {
+          "Code": "105504002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Dependence on walking stick",
+          "AltCodes": []
+        },
+        "Value": "Dependence on walking stick",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "129035000",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent with dressing",
+          "AltCodes": []
+        },
+        "Value": "Independent with dressing",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "46482-6",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Transferring",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "371153006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent",
+          "AltCodes": []
+        },
+        "Value": "Independent",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "47078008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Hearing",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "260379002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Impaired",
+          "AltCodes": []
+        },
+        "Value": "Impaired",
+        "ReferenceRange": {},
+        "Comments": []
+      }
+    ],
+    "Supplies": [
+      {
+        "Code": "14106009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cardiac Pacemaker",
+        "AltCodes": [],
+        "Status": "completed",
+        "DateTime": "2013-07-03"
+      }
+    ]
+  },
+  "GoalsText": "<paragraph ID=\"Goals\">Patient is targeting a pulse oximetry of 92%</paragraph>",
+  "Goals": [
+    {
+      "Code": "59408-5",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Oxygen saturation in Arterial blood by Pulse oximetry",
+      "AltCodes": [],
+      "DateTime": "2012-12-31T23:59:59.999Z",
+      "CodedValue": {
+        "AltCodes": []
+      },
+      "Value": "92",
+      "Units": "%",
+      "StartDate": "2013-09-02",
+      "EndDate": "2013-09-02",
+      "Priority": {
+        "Code": "394849002",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "High priority"
+      },
+      "AchievementStatus": {
+        "Name": "On track"
+      },
+      "Milestones": [],
+      "Comments": []
+    }
+  ],
+  "HealthConcernsText": "<table><thead><tr><th>Health Concern</th><th>Date</th><th>Related Problem</th></tr></thead><tbody><tr ID=\"Concern1\"><td ID=\"Concern1Issue1\">Concerned about being contagious and infecting roommate.</td><td>Concern from 03/02/2014</td><td>Community Acquired Pneumonia</td></tr></tbody></table>",
+  "HealthConcerns": [
+    {
+      "Category": {
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "Code": "385093006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Community Acquired Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "TargetSite": {
+        "AltCodes": []
+      },
+      "Status": "active",
+      "Comments": []
+    }
+  ],
+  "ImmunizationText": "<table width=\"100%\"><thead><tr><th>Vaccine</th><th>Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"immun2\">Influenza virus vaccine, IM</td><td>May 2012</td><td>Completed</td></tr><tr><td ID=\"immun4\">Tetanus and diphtheria toxoids, IM</td><td>Apr 2012</td><td>Completed</td></tr></tbody></table>",
+  "Immunizations": [
+    {
+      "DateTime": "2012-05-10T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "88",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Influenza virus vaccine",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    },
+    {
+      "DateTime": "2012-04-01T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "103",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Tetanus and diphtheria toxoids - preservative free",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    }
+  ],
+  "Insurances": [
+    {
+      "Plan": {
+        "ID": "31572",
+        "IDType": "2.16.840.1.113883.4.642.3.520",
+        "Name": "HMO Deductible Plan"
+      },
+      "Company": {
+        "ID": "60054",
+        "Name": "aetna (60054 0131)",
+        "Address": {
+          "StreetAddress": "PO Box 14080",
+          "City": "Lexington",
+          "State": "KY",
+          "ZIP": "40512-4079",
+          "County": "Fayette",
+          "Country": "US"
+        },
+        "PhoneNumber": "+18089541123"
+      },
+      "GroupNumber": "847025-024-0009",
+      "GroupName": "Accelerator Labs",
+      "EffectiveDate": "2015-01-01",
+      "ExpirationDate": "2020-12-31",
+      "PolicyNumber": "9140860055",
+      "Insured": {
+        "Identifiers": [],
+        "Address": {}
+      }
+    }
+  ],
+  "MedicalEquipmentText": "<table width=\"100%\"><thead><tr><th>Supply/Device</th><th>Date Supplied</th></tr></thead><tbody><tr><td>Automatic implantable cardioverter/defibrillator</td><td>Nov 1999</td></tr><tr><td>Total hip replacement prosthesis</td><td>1998</td></tr><tr><td>Wheelchair</td><td>1999</td></tr></tbody></table>",
+  "MedicalEquipment": [
+    {
+      "Status": "completed",
+      "StartDate": "1999-11-01T05:00:00.000Z",
+      "Quantity": "2",
+      "Comments": [],
+      "Product": {
+        "Code": "72506001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Automatic implantable cardioverter/defibrillator",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1998-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "304120007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Total hip replacement prosthesis",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1999-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "58938008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Wheelchair",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    }
+  ],
+  "MedicationsText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Directions</th><th>Start Date</th><th>Status</th><th>Indications</th><th>Fill Instructions</th></tr></thead><tbody><tr><td ID=\"Med1\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td><td>Pneumonia (233604007 SNOMED CT)</td><td ID=\"FillIns\">Generic Substitition Allowed</td></tr></tbody></table>",
+  "Medications": [
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      },
+      "Indications": [],
+      "SupplyOrder": {}
+    },
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "IsPRN": true,
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      },
+      "Indications": [
+        {
+          "Code": "422587007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Nausea",
+          "AltCodes": []
+        }
+      ],
+      "SupplyOrder": {}
+    }
+  ],
+  "PlanOfCareText": "<table width=\"100%\"><thead><tr><th>Planned Activity</th><th>Planned Date</th></tr></thead><tbody><tr><td>Consultation with Dr George Potomac for Asthma</td><td>20120820</td></tr><tr><td>Chest X-ray</td><td>20120826</td></tr><tr><td>Sputum Culture</td><td>20120820</td></tr></tbody></table>",
+  "PlanOfCare": {
+    "Orders": [
+      {
+        "Code": "624-7",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "Name": "Sputum Culture",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-26T05:00:00.000Z"
+      }
+    ],
+    "Encounters": [
+      {
+        "Code": "99241",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "Office consultation - 15 minutes",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": "Intent",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "MedicationAdministration": [
+      {
+        "Status": "Intent",
+        "Dose": {
+          "Quantity": "81",
+          "Units": "milliGRAM(s)"
+        },
+        "Rate": {},
+        "Route": {
+          "Code": "C38288",
+          "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          "CodeSystemName": "NCI Thesaurus",
+          "Name": "ORAL",
+          "AltCodes": []
+        },
+        "StartDate": "2012-10-02T05:00:00.000Z",
+        "EndDate": "2012-10-31T04:59:00.000Z",
+        "Frequency": {},
+        "Product": {
+          "Code": "1191",
+          "CodeSystem": "2.16.840.1.113883.6.88",
+          "CodeSystemName": "RxNorm",
+          "Name": "aspirin",
+          "AltCodes": []
+        }
+      }
+    ],
+    "Supplies": [],
+    "Services": [
+      {
+        "Code": "427519008",
+        "CodeSystem": "2.16.840.1.113883.11.20.9.34",
+        "CodeSystemName": "patientEducationType",
+        "Name": "Caregiver",
+        "AltCodes": [],
+        "Status": "Intent"
+      }
+    ]
+  },
+  "ProblemsText": "<list><item ID=\"problem1\">Pneumonia : Status - Resolved</item><item ID=\"problem2\">Asthma : Status - Active</item></list>",
+  "Problems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "233604007",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        },
+        {
+          "Code": "486",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    },
+    {
+      "StartDate": "2007-10-17T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "195967001",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Asthma",
+      "AltCodes": [
+        {
+          "Code": "J45.909",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Asthma"
+        },
+        {
+          "Code": "493.90",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Asthma"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ProceduresText": "<table width=\"100%\"><thead><tr><th>Procedure</th><th>Date</th></tr></thead><tbody><tr><td ID=\"Proc2\">Chest X-Ray</td><td>8/7/2012</td></tr></tbody></table>",
+  "Procedures": {
+    "Observations": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake observation",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "active",
+        "TargetSite": {
+          "Code": "302539009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire hand (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "completed",
+        "TargetSite": {
+          "Code": "181608004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire chest wall (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Services": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake action",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "aborted",
+        "Comments": []
+      }
+    ]
+  },
+  "ResolvedProblemsText": "<list><item ID=\"problem1\">Tobacco abuse : Status - Resolved</item></list>",
+  "ResolvedProblems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "110483000",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Tobacco abuse",
+      "AltCodes": [
+        {
+          "Code": "Z72.0",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "305.1",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "55885",
+          "CodeSystem": "2.16.840.1.113883.3.247.1.1",
+          "CodeSystemName": "Intelligent Medical Objects ProblemIT",
+          "Name": "Tobacco abuse"
+        }
+      ],
+      "Category": {
+        "Code": "64572001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Tobacco abuse",
+        "AltCodes": [
+          {
+            "Code": "75323-6",
+            "CodeSystem": "2.16.840.1.113883.6.1",
+            "CodeSystemName": "LOINC",
+            "Name": "Tobacco abuse"
+          }
+        ]
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": []
+    }
+  ],
+  "ResultText": "<table><tbody><tr><td colspan=\"2\">LABORATORY INFORMATION</td></tr><tr><td colspan=\"2\">Chemistries and drug levels</td></tr><tr><td ID=\"result1\">HGB (M 13-18 g/dl; F 12-16 g/dl)</td><td>13.2</td></tr><tr><td ID=\"result2\">WBC (4.3-10.8 10+3/ul)</td><td>6.7</td></tr><tr><td ID=\"result3\">PLT (135-145 meq/l)</td><td>123 (L)</td></tr></tbody></table>",
+  "Results": [
+    {
+      "Code": "43789009",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "CBC WO DIFFERENTIAL",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "Final",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "CollectionDateTime": "2012-08-10T14:00:00.000Z",
+        "Identifiers": [
+          "1.2.840.113840.5^BL-201201-01"
+        ],
+        "Source": {
+          "Code": "420135007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Blood, whole"
+        },
+        "TargetSite": {
+          "Code": "LA",
+          "CodeSystem": "2.16.840.1.113883.18.81",
+          "CodeSystemName": "Body Site",
+          "Name": "Left Arm"
+        }
+      },
+      "Observations": [
+        {
+          "Code": "30313-1",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "HGB",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "10.2",
+          "ValueType": "PhysicalQuantity",
+          "Units": "g/dl",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "33765-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "WBC",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "12.3",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "26515-7",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "PLT",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Low",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "123",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "Code": "624-7",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Sputum Culture",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "In Progress",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "Identifiers": [],
+        "Source": {},
+        "TargetSite": {}
+      },
+      "Observations": [
+        {
+          "Code": "86243-3",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Color of Sputum",
+          "AltCodes": [],
+          "Status": "Final",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "Code": "54662009",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Green",
+            "AltCodes": []
+          },
+          "Value": "Green",
+          "ValueType": "Code",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    }
+  ],
+  "SocialHistoryText": "<table width=\"100%\"><thead><tr><th>Social History Element</th><th>Description</th><th>Effective Dates</th></tr></thead><tbody><tr><td ID=\"soc1\">smoking</td><td>Former Smoker (1 pack per day</td><td>20050501 to 20110227</td></tr><tr><td ID=\"soc2\">smoking</td><td>Current Everyday Smoker 2 packs per day</td><td>20110227 - today</td></tr></tbody></table>",
+  "SocialHistory": {
+    "Observations": [
+      {
+        "Code": "160573003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Alcohol Consumption",
+        "AltCodes": [],
+        "Value": {
+          "AltCodes": []
+        },
+        "ValueText": "None",
+        "StartDate": "1990-05-01T04:00:00.000Z",
+        "Comments": []
+      }
+    ],
+    "Pregnancy": [],
+    "TobaccoUse": [
+      {
+        "Code": "8517006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Former smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": true,
+        "StartDate": "2015-06-03T09:35:00.000Z",
+        "Comments": []
+      },
+      {
+        "Code": "65568007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cigarette smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": false,
+        "StartDate": "2005-05-01",
+        "EndDate": "2008-09-01",
+        "Comments": []
+      }
+    ]
+  },
+  "VitalSignsText": "<table width=\"100%\"><thead><tr><th align=\"right\">Date / Time: </th><th>Nov 1, 2011</th><th>August 6, 2012</th></tr></thead><tbody><tr><th align=\"left\">Height</th><td ID=\"vit1\">69 inches</td><td ID=\"vit2\">69 inches</td></tr><tr><th align=\"left\">Weight</th><td ID=\"vit3\">189 lbs</td><td ID=\"vit4\">194 lbs</td></tr><tr><th align=\"left\">Blood Pressure</th><td ID=\"vit5\">132/86 mmHg</td><td ID=\"vit6\">145/88 mmHg</td></tr></tbody></table>",
+  "VitalSigns": [
+    {
+      "DateTime": "1999-11-14T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "86",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "132",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "DateTime": "2000-04-07T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "88",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "145",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/clinicalsummary_visitpush.json
+++ b/tests/fixtures/clinicalsummary_visitpush.json
@@ -1,0 +1,1694 @@
+{
+  "Meta": {
+    "DataModel": "Clinical Summary",
+    "EventType": "VisitPush",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "ef9e7448-7f65-4432-aa96-059647e9b358",
+        "Name": "Visit Push Endpoint"
+      }
+    ],
+    "Logs": [
+      {
+        "ID": "d9f5d293-7110-461e-a875-3beb089e79f3",
+        "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    }
+  },
+  "Header": {
+    "Document": {
+      "Author": {
+        "ID": "4356789876",
+        "IDType": "2.16.840.1.113883.4.6",
+        "FirstName": "Pat",
+        "LastName": "Granite",
+        "Credentials": [
+          "MD"
+        ],
+        "Address": {
+          "StreetAddress": "123 Main St.",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+16085551234"
+        },
+        "Location": {}
+      },
+      "ID": "75cb4ad4-e5f9-4cd3-8750-eb5050521e0d",
+      "Locale": "US",
+      "Title": "Community Health and Hospitals: Annual Physical",
+      "DateTime": "2012-09-12T00:00:00.000Z",
+      "Type": "Progress Note",
+      "TypeCode": {
+        "Code": "18842-5",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Progress Note"
+      },
+      "Confidentiality": {
+        "Code": "R",
+        "CodeSystem": "2.16.840.1.113883.5.25",
+        "CodeSystemName": "Confidentiality",
+        "Name": "restricted"
+      },
+      "Custodian": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      },
+      "Visit": {
+        "StartDateTime": "2022-08-03T18:06:43.590Z",
+        "EndDateTime": "2022-08-03T18:06:43.590Z",
+        "Reason": "Annual Physical",
+        "VisitNumber": "30311442",
+        "Type": {
+          "Code": "99202",
+          "CodeSystem": "2.16.840.1.113883.6.12",
+          "CodeSystemName": "CPT",
+          "Name": "Office visit",
+          "AltCodes": []
+        },
+        "Location": {
+          "Type": "Outpatient Clinic",
+          "Facility": "RHS Vista Oaks Clinic",
+          "Department": "Vista Oaks Clinic"
+        },
+        "DischargeDisposition": {
+          "AltCodes": []
+        }
+      }
+    },
+    "Patient": {
+      "Identifiers": [
+        {
+          "ID": "1234",
+          "IDType": "2.16.840.1.113883.4.6"
+        }
+      ],
+      "Demographics": {
+        "FirstName": "Myra",
+        "LastName": "Jones",
+        "DOB": "1947-05-01",
+        "SSN": "123-101-1234",
+        "Sex": "Female",
+        "Address": {
+          "StreetAddress": "1357 Amber Drive",
+          "City": "Beaverton",
+          "State": "OR",
+          "Country": "US",
+          "ZIP": "97006"
+        },
+        "PhoneNumber": {
+          "Home": "+18162766909"
+        },
+        "EmailAddresses": [
+          {
+            "Address": "[email\u00a0protected]"
+          }
+        ],
+        "Race": "White",
+        "RaceCodes": [
+          {
+            "Code": "2106-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "White"
+          },
+          {
+            "Code": "2112-1",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "German"
+          }
+        ],
+        "Ethnicity": "Hispanic or Latino",
+        "EthnicGroupCodes": [
+          {
+            "Code": "2135-2",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Hispanic or Latino"
+          },
+          {
+            "Code": "2149-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Mexican American"
+          }
+        ],
+        "Religion": "Christian (non-Catholic, non-specific)",
+        "MaritalStatus": "Married",
+        "IsDeceased": false
+      },
+      "Organization": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      }
+    },
+    "PCP": {
+      "Credentials": [],
+      "Address": {},
+      "EmailAddresses": [],
+      "PhoneNumber": {},
+      "Location": {}
+    }
+  },
+  "AdmissionDiagnosis": [],
+  "AdvanceDirectivesText": "<table width=\"100%\"><thead><tr><th>Directive</th><th>Description</th><th>Verification</th><th>Supporting Document(s)</th></tr></thead><tbody><tr><td>Resuscitation status</td><td ID=\"AD1\">Do not resuscitate</td><td>Dr. Robert Dolin, Nov 07, 1999</td><td><linkHtml href=\"AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf\">Advance directive</linkHtml></td></tr></tbody></table>",
+  "AdvanceDirectives": [
+    {
+      "Type": {
+        "Code": "304251008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resuscitation",
+        "AltCodes": []
+      },
+      "Code": "304253006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Do not resuscitate",
+      "AltCodes": [],
+      "StartDate": "2011-02-13T05:00:00.000Z",
+      "ExternalReference": "AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf",
+      "VerifiedBy": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr."
+        }
+      ],
+      "Custodians": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr.",
+          "Address": {
+            "StreetAddress": "21 North Ave.",
+            "City": "Burlington",
+            "State": "MA",
+            "Country": "USA",
+            "ZIP": "02368"
+          }
+        }
+      ]
+    }
+  ],
+  "AllergyText": "<table width=\"100%\"><thead><tr><th>Substance</th><th>Reaction</th><th>Severity</th><th>Status</th></tr></thead><tbody><tr><td>Penicillin G benzathine</td><td ID=\"reaction1\">Hives</td><td ID=\"severity1\">Moderate to severe</td><td>Inactive</td></tr><tr><td>Codeine</td><td ID=\"reaction2\">Shortness of Breath</td><td ID=\"severity2\">Moderate</td><td>Active</td></tr><tr><td>Aspirin</td><td ID=\"reaction3\">Hives</td><td ID=\"severity3\">Mild to moderate</td><td>Active</td></tr></tbody></table>",
+  "Allergies": [
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "7982",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Penicillin G benzathine",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "28926001",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Rash",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "255604002",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild"
+          }
+        },
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITH",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "High criticality"
+      },
+      "Status": {
+        "Code": "73425007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Inactive"
+      },
+      "Comments": [
+        {
+          "Text": "Noted when patient took penicillin for ear infection."
+        }
+      ]
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "2670",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Codeine",
+        "AltCodes": [
+          {
+            "Code": "11QV9BS0CB",
+            "CodeSystem": "2.16.840.1.113883.4.9",
+            "CodeSystemName": "UNII",
+            "Name": "Codeine"
+          }
+        ]
+      },
+      "Reaction": [
+        {
+          "Code": "267036007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Shortness of Breath",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITL",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Low criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "1191",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Aspirin",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "371923003",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild to moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "371923003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Mild to moderate"
+      },
+      "Criticality": {
+        "Code": "CRITU",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Unable to assess criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    }
+  ],
+  "AssessmentText": "<list><item>Recurrent GI bleed of unknown etiology; hypotension perhaps secondary to this but as likely secondary to polypharmacy.</item><item>Acute on chronic anemia secondary to #1.</item><item>Azotemia, acute renal failure with volume loss secondary to #1.</item><item>Hyperkalemia secondary to #3 and on ACE and K+ supplement.</item><item>Other chronic diagnoses as noted above, currently stable.</item></list>Also, this person has back problems.",
+  "Assessment": {
+    "Diagnoses": [
+      {
+        "Value": "Displacement of lumbar intervertebral disc without myelopathy",
+        "DateTime": "2009-11-01T05:00:00.000Z",
+        "IsNegativeIndicator": false,
+        "Codes": [
+          {
+            "Code": "202708005",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED-CT",
+            "Name": "Herniated lumbar intervertebral disc"
+          },
+          {
+            "Code": "M51.26",
+            "CodeSystem": "2.16.840.1.113883.6.90",
+            "CodeSystemName": "ICD-10",
+            "Name": "Herniated lumbar intervertebral disc"
+          }
+        ],
+        "Comments": []
+      },
+      {
+        "Value": "Thoracic or lumbosacral neuritis or radiculitis, unspecified",
+        "DateTime": "2009-11-01T05:00:00.000Z",
+        "IsNegativeIndicator": false,
+        "Codes": [
+          {
+            "Code": "M54.16",
+            "CodeSystem": "2.16.840.1.113883.6.90",
+            "CodeSystemName": "ICD-10",
+            "Name": "Right lumbar radiculopathy"
+          }
+        ],
+        "Comments": []
+      }
+    ]
+  },
+  "CareTeams": [],
+  "ChiefComplaintText": "<paragraph>Dark stools.</paragraph>",
+  "DischargeDiagnosis": [],
+  "DischargeMedications": [],
+  "EncountersText": "<table width=\"100%\"><thead><tr><th>Encounter</th><th>Performer</th><th>Location</th><th>Date</th></tr></thead><tbody><tr ID=\"Encounter1\"><td>Pnuemonia</td><td>Dr Henry Seven</td><td>Community Health and Hospitals</td><td>20120806</td></tr></tbody></table>",
+  "Encounters": [
+    {
+      "Identifiers": [
+        {
+          "ID": "2376492",
+          "IDType": "URMC Epic CSN"
+        },
+        {
+          "ID": "8237334",
+          "IDType": "1.35.829.5.238422.9.10"
+        }
+      ],
+      "Type": {
+        "Code": "99222",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "InPatient Admission",
+        "AltCodes": []
+      },
+      "DateTime": "2012-08-06T04:00:00.000Z",
+      "Providers": [
+        {
+          "Credentials": [],
+          "Address": {},
+          "EmailAddresses": [],
+          "PhoneNumber": {},
+          "Location": {},
+          "Role": {
+            "Code": "59058001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "General Physician",
+            "AltCodes": []
+          }
+        }
+      ],
+      "Locations": [
+        {
+          "Identifiers": [],
+          "Telecom": [],
+          "Address": {
+            "StreetAddress": "1002 Healthcare Dr",
+            "City": "Portland",
+            "State": "OR",
+            "Country": "US",
+            "ZIP": "97266"
+          },
+          "Type": {
+            "Code": "1160-1",
+            "CodeSystem": "2.16.840.1.113883.6.259",
+            "CodeSystemName": "HealthcareServiceLocation",
+            "Name": "Urgent Care Center",
+            "AltCodes": []
+          },
+          "Name": "Community Health and Hospitals"
+        }
+      ],
+      "Diagnosis": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "ReasonForVisit": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "DischargeDisposition": {
+        "AltCodes": []
+      }
+    }
+  ],
+  "FamilyHistoryText": "<paragraph>Father (deceased)</paragraph><table width=\"100%\"><thead><tr><th>Diagnosis</th><th>Age At Onset</th></tr></thead><tbody><tr><td>Myocardial Infarction (cause of death)</td><td>57</td></tr><tr><td>Diabetes</td><td>40</td></tr></tbody></table>",
+  "FamilyHistory": [
+    {
+      "Relation": {
+        "Code": "FTH",
+        "CodeSystem": "2.16.840.1.113883.5.111",
+        "CodeSystemName": "HL7 FamilyMember",
+        "Name": "Father",
+        "Demographics": {
+          "Sex": "Male",
+          "DOB": "1912-01-01"
+        },
+        "IsDeceased": true
+      },
+      "Problems": [
+        {
+          "Code": "22298006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Myocardial infarction",
+          "AltCodes": [],
+          "Type": {
+            "Code": "55607006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Problem"
+          },
+          "AgeAtOnset": "57"
+        },
+        {
+          "Code": "46635009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Diabetes mellitus type 1",
+          "AltCodes": [],
+          "Type": {
+            "Code": "64572001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Condition"
+          },
+          "DateTime": "1994-01-01T05:00:00.000Z",
+          "AgeAtOnset": "40"
+        }
+      ]
+    }
+  ],
+  "FunctionalStatusText": "<table><thead><tr><th>Assessment</th><th>Date</th><th>Results</th><th>Comments</th></tr></thead><tbody><tr ID=\"FS_Narrative1\"><td ID=\"FS_Type\">Functional Status</td><td>August 15 2012, 5:32pm</td><td ID=\"FS_Finding1\">Dependence on walking stick</td><td></td></tr><tr ID=\"FS_Narrative2\"><td ID=\"FS_Type\">Functional Status</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent with dressing</td><td></td></tr><tr ID=\"FS_Narrative3\"><td ID=\"FS_Type\">Transferring</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent</td><td></td></tr><tr ID=\"FS_Narrative4\"><td ID=\"FS_Type\">Hearing</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Impaired</td><td></td></tr></tbody></table>",
+  "FunctionalStatus": {
+    "Observations": [
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2012-08-15",
+        "CodedValue": {
+          "Code": "105504002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Dependence on walking stick",
+          "AltCodes": []
+        },
+        "Value": "Dependence on walking stick",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "129035000",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent with dressing",
+          "AltCodes": []
+        },
+        "Value": "Independent with dressing",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "46482-6",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Transferring",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "371153006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent",
+          "AltCodes": []
+        },
+        "Value": "Independent",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "47078008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Hearing",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "260379002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Impaired",
+          "AltCodes": []
+        },
+        "Value": "Impaired",
+        "ReferenceRange": {},
+        "Comments": []
+      }
+    ],
+    "Supplies": [
+      {
+        "Code": "14106009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cardiac Pacemaker",
+        "AltCodes": [],
+        "Status": "completed",
+        "DateTime": "2013-07-03"
+      }
+    ]
+  },
+  "GoalsText": "<paragraph ID=\"Goals\">Patient is targeting a pulse oximetry of 92%</paragraph>",
+  "Goals": [
+    {
+      "Code": "59408-5",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Oxygen saturation in Arterial blood by Pulse oximetry",
+      "AltCodes": [],
+      "DateTime": "2012-12-31T23:59:59.999Z",
+      "CodedValue": {
+        "AltCodes": []
+      },
+      "Value": "92",
+      "Units": "%",
+      "StartDate": "2013-09-02",
+      "EndDate": "2013-09-02",
+      "Priority": {
+        "Code": "394849002",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "High priority"
+      },
+      "AchievementStatus": {
+        "Name": "On track"
+      },
+      "Milestones": [],
+      "Comments": []
+    }
+  ],
+  "HealthConcernsText": "<table><thead><tr><th>Health Concern</th><th>Date</th><th>Related Problem</th></tr></thead><tbody><tr ID=\"Concern1\"><td ID=\"Concern1Issue1\">Concerned about being contagious and infecting roommate.</td><td>Concern from 03/02/2014</td><td>Community Acquired Pneumonia</td></tr></tbody></table>",
+  "HealthConcerns": [
+    {
+      "Category": {
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "Code": "385093006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Community Acquired Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "TargetSite": {
+        "AltCodes": []
+      },
+      "Status": "active",
+      "Comments": []
+    }
+  ],
+  "HistoryOfPresentIllnessText": "<list><item><caption>Kelp, Lonnie Ray Sr., MD PHD - 10/21/2014 8:07 PM PST</caption><paragraph>Date: 10/21/2014<br/><br/>Pre-procedure diagnosis: L5 S1 Acute Lumbar Radiculopathy (Right)<br/><br/>Post-procedure diagnosis: Same<br/><br/>Procedure: 1) L5S1 Transforaminal Epidural Steroid injection(Right)<br/>2) Fluoroscopic Guidance for needle placement<br/><br/>Complications: None<br/><br/>CONSENT: Today's procedure, its potential benefits as well as its risks and potential side effects were reviewed. Discussed risks of the procedure include bleeding, infection, nerve irritation or damage, reactions to the medications, headache, failure of the pain to improve, and exacerbation of the pain were explained to the patient, who verbalized understanding and who wished to proceed. Informed consent was signed.<br/><br/>DESCRIPTION OF PROCEDURES: After written informed consent was obtained, the patient was taken to the fluoroscopy suite. Anatomical landmarks were identified by way of fluoroscopy in multiple views. Strict aseptic technique was utilized.<br/><br/>A 22-gauge 3-1/2-inch needle was then incrementally advanced using multiple fluoroscopic views from an oblique approach into the Right L5S1 lumbar intervertebral space. Both AP and lateral views were used to confirm final needle placement. After negative aspiration, Omniopaque 240 contrast was injected which delineated epidural without vascular flow and a normal epidurogram under fluoroscopy in the lateral and AP view. After negative aspiration was reconfirmed, a 1.0 mL of 0.25% Bupivicaine and 1mL of 40 mg/mL of Kenalog was slowly injected into the epidural space.<br/><br/>All needles were removed intact. Hemostasis was maintained. There were no complications. The area was cleaned and a Band-Aid placed as necessary. The patient tolerated the procedure well and all needles were removed intact. After a period of observation, the patient was noted to be hemodynamically stable and neurovascularly intact following the procedure as prior to the procedure, and was ultimately discharged to home with supervision in good condition. The patient was instructed to schedule an appointment in the office within 2 weeks.<br/>Lonnie Ray Kelp Sr., MD PHD<br/><br/></paragraph></item></list>",
+  "ImmunizationText": "<table width=\"100%\"><thead><tr><th>Vaccine</th><th>Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"immun2\">Influenza virus vaccine, IM</td><td>May 2012</td><td>Completed</td></tr><tr><td ID=\"immun4\">Tetanus and diphtheria toxoids, IM</td><td>Apr 2012</td><td>Completed</td></tr></tbody></table>",
+  "Immunizations": [
+    {
+      "DateTime": "2012-05-10T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "88",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Influenza virus vaccine",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    },
+    {
+      "DateTime": "2012-04-01T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "103",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Tetanus and diphtheria toxoids - preservative free",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    }
+  ],
+  "InstructionsText": "Please carefully follow the subsequent instructions and patient education:<br/><br/><list><item>Floss</item><item>Brush teeth twice daily</item></list><br/><br/>Scarf tying instructions may be found online.",
+  "Insurances": [
+    {
+      "Plan": {
+        "ID": "31572",
+        "IDType": "2.16.840.1.113883.4.642.3.520",
+        "Name": "HMO Deductible Plan"
+      },
+      "Company": {
+        "ID": "60054",
+        "Name": "aetna (60054 0131)",
+        "Address": {
+          "StreetAddress": "PO Box 14080",
+          "City": "Lexington",
+          "State": "KY",
+          "ZIP": "40512-4079",
+          "County": "Fayette",
+          "Country": "US"
+        },
+        "PhoneNumber": "+18089541123"
+      },
+      "GroupNumber": "847025-024-0009",
+      "GroupName": "Accelerator Labs",
+      "EffectiveDate": "2015-01-01",
+      "ExpirationDate": "2020-12-31",
+      "PolicyNumber": "9140860055",
+      "Insured": {
+        "Identifiers": [],
+        "Address": {}
+      }
+    }
+  ],
+  "InterventionsText": "Patient practiced use of novel prosthesis including movements formerly neglected including distal extension and retroflexive hyperextension.",
+  "MedicalEquipmentText": "<table width=\"100%\"><thead><tr><th>Supply/Device</th><th>Date Supplied</th></tr></thead><tbody><tr><td>Automatic implantable cardioverter/defibrillator</td><td>Nov 1999</td></tr><tr><td>Total hip replacement prosthesis</td><td>1998</td></tr><tr><td>Wheelchair</td><td>1999</td></tr></tbody></table>",
+  "MedicalEquipment": [
+    {
+      "Status": "completed",
+      "StartDate": "1999-11-01T05:00:00.000Z",
+      "Quantity": "2",
+      "Comments": [],
+      "Product": {
+        "Code": "72506001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Automatic implantable cardioverter/defibrillator",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1998-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "304120007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Total hip replacement prosthesis",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1999-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "58938008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Wheelchair",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    }
+  ],
+  "MedicalHistoryText": "<table><colgroup><col width=\"38%\"/><col width=\"12%\"/><col width=\"50%\"/></colgroup><thead><tr><th>Medical History</th><th>Date</th><th>Comments</th></tr></thead><tbody><tr ID=\"medhist54\"><td>Unspecified essential hypertension</td><td>1985</td><td>Diagnosed age 56. Initially treated with sodium restriction, diet, exercise. Diuretics started ~1986, taken sporadically since that time. Patient admits to poor compliance with med regimen. </td></tr><tr ID=\"medhist55\"><td>Variants of migraine, not elsewhere classified, without mention of intractable migraine without mention of status migrainosus</td><td>1989</td><td>Cluster headaches for approximately 5 yr period, occurring 2-3 X yearly. None since 1997.</td></tr><tr ID=\"medhist56\"><td>Acquired hypothyroidism</td><td>1998</td><td/></tr></tbody></table>",
+  "MedicationsText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Directions</th><th>Start Date</th><th>Status</th><th>Indications</th><th>Fill Instructions</th></tr></thead><tbody><tr><td ID=\"Med1\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td><td>Pneumonia (233604007 SNOMED CT)</td><td ID=\"FillIns\">Generic Substitition Allowed</td></tr></tbody></table>",
+  "Medications": [
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      },
+      "Indications": [],
+      "SupplyOrder": {}
+    },
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "IsPRN": true,
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      },
+      "Indications": [
+        {
+          "Code": "422587007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Nausea",
+          "AltCodes": []
+        }
+      ],
+      "SupplyOrder": {}
+    }
+  ],
+  "MedicationsAdministeredText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Start Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"Med2\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td></tr></tbody></table>",
+  "MedicationsAdministered": [
+    {
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      }
+    },
+    {
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      }
+    }
+  ],
+  "NoteSections": [
+    {
+      "Code": "11504-8",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Surgical operation note",
+      "AltCodes": [],
+      "Title": "OR Notes",
+      "Text": "<list> <item> <caption>OR PostOp - Pat Granite, MD - 10/20/2021  4:55 PM CDT</caption> <content ID=\"Note37\">Example note. <br />Signed by Pat Granite on 10/20/2021</content> </item> </list>",
+      "Notes": [
+        {
+          "Code": "34109-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "OR PostOp",
+          "AltCodes": [
+            {
+              "Code": "34875-5",
+              "CodeSystem": "2.16.840.1.113883.6.1",
+              "CodeSystemName": "LOINC",
+              "Name": "OR PostOp"
+            }
+          ],
+          "ContentType": "Plain Text",
+          "FileContents": "<content ID=\"Note37\">Example note. <br />Signed by Pat Granite on 10/20/2021</content>",
+          "DateTime": "2021-10-20T21:55:00.000Z",
+          "Status": "completed",
+          "Encounter": {
+            "Identifiers": [
+              {
+                "ID": "10000048107",
+                "IDType": "1.2.840.114350.1.13.3440.1.7.3.698084.8"
+              }
+            ],
+            "Type": {
+              "Code": "AMB",
+              "CodeSystem": "2.16.840.1.113883.5.4",
+              "AltCodes": []
+            },
+            "DateTime": "2021-10-20T16:55:00.000Z"
+          }
+        }
+      ]
+    }
+  ],
+  "ObjectiveText": "<list><item>Chest: clear to ausc. No rales, normal breath sounds</item><item>Heart: RR, PMI in normal location and no heave or evidence ofcardiomegaly,normal heart sounds, no murm or gallop</item></list>",
+  "PhysicalExamText": "All examinations performed within normal limits.<br/><br/>WNL<br/><br/>Nothing to report here.",
+  "PlanOfCareText": "<table width=\"100%\"><thead><tr><th>Planned Activity</th><th>Planned Date</th></tr></thead><tbody><tr><td>Consultation with Dr George Potomac for Asthma</td><td>20120820</td></tr><tr><td>Chest X-ray</td><td>20120826</td></tr><tr><td>Sputum Culture</td><td>20120820</td></tr></tbody></table>",
+  "PlanOfCare": {
+    "Orders": [
+      {
+        "Code": "624-7",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "Name": "Sputum Culture",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-26T05:00:00.000Z"
+      }
+    ],
+    "Encounters": [
+      {
+        "Code": "99241",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "Office consultation - 15 minutes",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": "Intent",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "MedicationAdministration": [
+      {
+        "Status": "Intent",
+        "Dose": {
+          "Quantity": "81",
+          "Units": "milliGRAM(s)"
+        },
+        "Rate": {},
+        "Route": {
+          "Code": "C38288",
+          "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          "CodeSystemName": "NCI Thesaurus",
+          "Name": "ORAL",
+          "AltCodes": []
+        },
+        "StartDate": "2012-10-02T05:00:00.000Z",
+        "EndDate": "2012-10-31T04:59:00.000Z",
+        "Frequency": {},
+        "Product": {
+          "Code": "1191",
+          "CodeSystem": "2.16.840.1.113883.6.88",
+          "CodeSystemName": "RxNorm",
+          "Name": "aspirin",
+          "AltCodes": []
+        }
+      }
+    ],
+    "Supplies": [],
+    "Services": [
+      {
+        "Code": "427519008",
+        "CodeSystem": "2.16.840.1.113883.11.20.9.34",
+        "CodeSystemName": "patientEducationType",
+        "Name": "Caregiver",
+        "AltCodes": [],
+        "Status": "Intent"
+      }
+    ]
+  },
+  "ProblemsText": "<list><item ID=\"problem1\">Pneumonia : Status - Resolved</item><item ID=\"problem2\">Asthma : Status - Active</item></list>",
+  "Problems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "233604007",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        },
+        {
+          "Code": "486",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    },
+    {
+      "StartDate": "2007-10-17T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "195967001",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Asthma",
+      "AltCodes": [
+        {
+          "Code": "J45.909",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Asthma"
+        },
+        {
+          "Code": "493.90",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Asthma"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ProceduresText": "<table width=\"100%\"><thead><tr><th>Procedure</th><th>Date</th></tr></thead><tbody><tr><td ID=\"Proc2\">Chest X-Ray</td><td>8/7/2012</td></tr></tbody></table>",
+  "Procedures": {
+    "Observations": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake observation",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "active",
+        "TargetSite": {
+          "Code": "302539009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire hand (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "completed",
+        "TargetSite": {
+          "Code": "181608004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire chest wall (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Services": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake action",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "aborted",
+        "Comments": []
+      }
+    ]
+  },
+  "ReasonForReferralText": "<table><colgroup><col width=\"16%\"/><col width=\"16%\"/><col width=\"18%\"/><col width=\"16%\"/><col width=\"16%\"/><col width=\"18%\"/></colgroup><thead><tr><th>Incoming Referral</th><th>Reason</th><th>Specialty</th><th>Diagnoses / Procedures</th><th>Referred By Contact</th><th>Referred To Contact</th></tr></thead><tbody><tr><td><paragraph>Consult, Test &amp; Treat (Routine)</paragraph></td><td/><td>BA-Physical Medicine / Physical Medicine and Rehab</td><td><paragraph>Diagnoses</paragraph><paragraph>Radiculopathy, lumbar region</paragraph><paragraph>L5S1 TTRANSFORMINAL ESI</paragraph><paragraph>L5S1 TTRANSFORMINAL ESI</paragraph><paragraph>Procedures</paragraph><paragraph>PR INJECT ANES/STEROID FORAMEN LUMBAR/SACRAL W IMG GUIDE ,1 LEVEL</paragraph><paragraph>INJECTION</paragraph></td><td><paragraph>Kelp, Lonnie Ray Sr., MD PHD</paragraph></td><td><paragraph>Kelp, Lonnie Ray Sr., MD PHD</paragraph></td></tr></tbody></table>",
+  "ReasonForVisitText": "<paragraph>Light stools.</paragraph>",
+  "ReasonForVisit": [
+    {
+      "Code": "27731006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Soft stool",
+      "AltCodes": [],
+      "Category": {
+        "Code": "8661-1",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Chief Complaint",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ResolvedProblemsText": "<list><item ID=\"problem1\">Tobacco abuse : Status - Resolved</item></list>",
+  "ResolvedProblems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "110483000",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Tobacco abuse",
+      "AltCodes": [
+        {
+          "Code": "Z72.0",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "305.1",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "55885",
+          "CodeSystem": "2.16.840.1.113883.3.247.1.1",
+          "CodeSystemName": "Intelligent Medical Objects ProblemIT",
+          "Name": "Tobacco abuse"
+        }
+      ],
+      "Category": {
+        "Code": "64572001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Tobacco abuse",
+        "AltCodes": [
+          {
+            "Code": "75323-6",
+            "CodeSystem": "2.16.840.1.113883.6.1",
+            "CodeSystemName": "LOINC",
+            "Name": "Tobacco abuse"
+          }
+        ]
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": []
+    }
+  ],
+  "ResultText": "<table><tbody><tr><td colspan=\"2\">LABORATORY INFORMATION</td></tr><tr><td colspan=\"2\">Chemistries and drug levels</td></tr><tr><td ID=\"result1\">HGB (M 13-18 g/dl; F 12-16 g/dl)</td><td>13.2</td></tr><tr><td ID=\"result2\">WBC (4.3-10.8 10+3/ul)</td><td>6.7</td></tr><tr><td ID=\"result3\">PLT (135-145 meq/l)</td><td>123 (L)</td></tr></tbody></table>",
+  "Results": [
+    {
+      "Code": "43789009",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "CBC WO DIFFERENTIAL",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "Final",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "CollectionDateTime": "2012-08-10T14:00:00.000Z",
+        "Identifiers": [
+          "1.2.840.113840.5^BL-201201-01"
+        ],
+        "Source": {
+          "Code": "420135007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Blood, whole"
+        },
+        "TargetSite": {
+          "Code": "LA",
+          "CodeSystem": "2.16.840.1.113883.18.81",
+          "CodeSystemName": "Body Site",
+          "Name": "Left Arm"
+        }
+      },
+      "Observations": [
+        {
+          "Code": "30313-1",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "HGB",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "10.2",
+          "ValueType": "PhysicalQuantity",
+          "Units": "g/dl",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "33765-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "WBC",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "12.3",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "26515-7",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "PLT",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Low",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "123",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "Code": "624-7",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Sputum Culture",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "In Progress",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "Identifiers": [],
+        "Source": {},
+        "TargetSite": {}
+      },
+      "Observations": [
+        {
+          "Code": "86243-3",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Color of Sputum",
+          "AltCodes": [],
+          "Status": "Final",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "Code": "54662009",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Green",
+            "AltCodes": []
+          },
+          "Value": "Green",
+          "ValueType": "Code",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    }
+  ],
+  "ReviewOfSystemsText": "<paragraph>Patient denies recent history of fever or malaise. Positive for weakness and shortness of breath. One episode of melena. No recent headaches. Positive for osteoarthritis in hips, knees and hands.</paragraph>",
+  "SocialHistoryText": "<table width=\"100%\"><thead><tr><th>Social History Element</th><th>Description</th><th>Effective Dates</th></tr></thead><tbody><tr><td ID=\"soc1\">smoking</td><td>Former Smoker (1 pack per day</td><td>20050501 to 20110227</td></tr><tr><td ID=\"soc2\">smoking</td><td>Current Everyday Smoker 2 packs per day</td><td>20110227 - today</td></tr></tbody></table>",
+  "SocialHistory": {
+    "Observations": [
+      {
+        "Code": "160573003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Alcohol Consumption",
+        "AltCodes": [],
+        "Value": {
+          "AltCodes": []
+        },
+        "ValueText": "None",
+        "StartDate": "1990-05-01T04:00:00.000Z",
+        "Comments": []
+      }
+    ],
+    "Pregnancy": [],
+    "TobaccoUse": [
+      {
+        "Code": "8517006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Former smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": true,
+        "StartDate": "2015-06-03T09:35:00.000Z",
+        "Comments": []
+      },
+      {
+        "Code": "65568007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cigarette smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": false,
+        "StartDate": "2005-05-01",
+        "EndDate": "2008-09-01",
+        "Comments": []
+      }
+    ]
+  },
+  "SubjectiveText": "<paragraph> Complaints of rectal bleeding, fatigue and a change in bowel patterns. Has several days of constipation alternating with diarrhea. </paragraph>",
+  "VitalSignsText": "<table width=\"100%\"><thead><tr><th align=\"right\">Date / Time: </th><th>Nov 1, 2011</th><th>August 6, 2012</th></tr></thead><tbody><tr><th align=\"left\">Height</th><td ID=\"vit1\">69 inches</td><td ID=\"vit2\">69 inches</td></tr><tr><th align=\"left\">Weight</th><td ID=\"vit3\">189 lbs</td><td ID=\"vit4\">194 lbs</td></tr><tr><th align=\"left\">Blood Pressure</th><td ID=\"vit5\">132/86 mmHg</td><td ID=\"vit6\">145/88 mmHg</td></tr></tbody></table>",
+  "VitalSigns": [
+    {
+      "DateTime": "1999-11-14T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "86",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "132",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "DateTime": "2000-04-07T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "88",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "145",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/clinicalsummary_visitquery.json
+++ b/tests/fixtures/clinicalsummary_visitquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Clinical Summary",
     "EventType": "VisitQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/clinicalsummary_visitqueryresponse.json
+++ b/tests/fixtures/clinicalsummary_visitqueryresponse.json
@@ -1,0 +1,1648 @@
+{
+  "Meta": {
+    "DataModel": "Clinical Summary",
+    "EventType": "VisitQueryResponse",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
+    "Test": true,
+    "Source": {
+      "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+      "Name": "Redox Dev Tools"
+    },
+    "Destinations": [
+      {
+        "ID": "ef9e7448-7f65-4432-aa96-059647e9b358",
+        "Name": "Visit Query Endpoint"
+      }
+    ],
+    "Logs": [
+      {
+        "ID": "d9f5d293-7110-461e-a875-3beb089e79f3",
+        "AttemptID": "925d1617-2fe0-468c-a14c-f8c04b572c54"
+      }
+    ],
+    "Message": {
+      "ID": 5565
+    },
+    "Transmission": {
+      "ID": 12414
+    }
+  },
+  "Header": {
+    "Document": {
+      "Author": {
+        "ID": "4356789876",
+        "IDType": "2.16.840.1.113883.4.6",
+        "FirstName": "Pat",
+        "LastName": "Granite",
+        "Credentials": [
+          "MD"
+        ],
+        "Address": {
+          "StreetAddress": "123 Main St.",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        },
+        "EmailAddresses": [],
+        "PhoneNumber": {
+          "Office": "+16085551234"
+        },
+        "Location": {}
+      },
+      "ID": "75cb4ad4-e5f9-4cd3-8750-eb5050521e0d",
+      "Locale": "US",
+      "Title": "Community Health and Hospitals: Annual Physical",
+      "DateTime": "2012-09-12T00:00:00.000Z",
+      "Type": "Progress Note",
+      "TypeCode": {
+        "Code": "18842-5",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Progress Note"
+      },
+      "Confidentiality": {
+        "Code": "R",
+        "CodeSystem": "2.16.840.1.113883.5.25",
+        "CodeSystemName": "Confidentiality",
+        "Name": "restricted"
+      },
+      "Custodian": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      },
+      "Visit": {
+        "StartDateTime": "2022-08-03T18:06:43.590Z",
+        "EndDateTime": "2022-08-03T18:06:43.590Z",
+        "Reason": "Annual Physical",
+        "VisitNumber": "30311442",
+        "Type": {
+          "Code": "99202",
+          "CodeSystem": "2.16.840.1.113883.6.12",
+          "CodeSystemName": "CPT",
+          "Name": "Office visit",
+          "AltCodes": []
+        },
+        "Location": {
+          "Type": "Outpatient Clinic",
+          "Facility": "RHS Vista Oaks Clinic",
+          "Department": "Vista Oaks Clinic"
+        },
+        "DischargeDisposition": {
+          "AltCodes": []
+        }
+      }
+    },
+    "Patient": {
+      "Identifiers": [
+        {
+          "ID": "1234",
+          "IDType": "2.16.840.1.113883.4.6"
+        }
+      ],
+      "Demographics": {
+        "FirstName": "Myra",
+        "LastName": "Jones",
+        "DOB": "1947-05-01",
+        "SSN": "123-101-1234",
+        "Sex": "Female",
+        "Address": {
+          "StreetAddress": "1357 Amber Drive",
+          "City": "Beaverton",
+          "State": "OR",
+          "Country": "US",
+          "ZIP": "97006"
+        },
+        "PhoneNumber": {
+          "Home": "+18162766909"
+        },
+        "EmailAddresses": [
+          {
+            "Address": "[email\u00a0protected]"
+          }
+        ],
+        "Race": "White",
+        "RaceCodes": [
+          {
+            "Code": "2106-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "White"
+          },
+          {
+            "Code": "2112-1",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "German"
+          }
+        ],
+        "Ethnicity": "Hispanic or Latino",
+        "EthnicGroupCodes": [
+          {
+            "Code": "2135-2",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Hispanic or Latino"
+          },
+          {
+            "Code": "2149-3",
+            "CodeSystem": "2.16.840.1.113883.6.238",
+            "CodeSystemName": "CDC Race and Ethnicity",
+            "Name": "Mexican American"
+          }
+        ],
+        "Religion": "Christian (non-Catholic, non-specific)",
+        "MaritalStatus": "Married",
+        "IsDeceased": false
+      },
+      "Organization": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        },
+        "Address": {},
+        "Telecom": []
+      }
+    },
+    "PCP": {
+      "Credentials": [],
+      "Address": {},
+      "EmailAddresses": [],
+      "PhoneNumber": {},
+      "Location": {}
+    }
+  },
+  "AdmissionDiagnosis": [],
+  "AdvanceDirectivesText": "<table width=\"100%\"><thead><tr><th>Directive</th><th>Description</th><th>Verification</th><th>Supporting Document(s)</th></tr></thead><tbody><tr><td>Resuscitation status</td><td ID=\"AD1\">Do not resuscitate</td><td>Dr. Robert Dolin, Nov 07, 1999</td><td><linkHtml href=\"AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf\">Advance directive</linkHtml></td></tr></tbody></table>",
+  "AdvanceDirectives": [
+    {
+      "Type": {
+        "Code": "304251008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resuscitation",
+        "AltCodes": []
+      },
+      "Code": "304253006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Do not resuscitate",
+      "AltCodes": [],
+      "StartDate": "2011-02-13T05:00:00.000Z",
+      "ExternalReference": "AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf",
+      "VerifiedBy": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr."
+        }
+      ],
+      "Custodians": [
+        {
+          "FirstName": "Robert",
+          "LastName": "Dolin",
+          "Credentials": "Dr.",
+          "Address": {
+            "StreetAddress": "21 North Ave.",
+            "City": "Burlington",
+            "State": "MA",
+            "Country": "USA",
+            "ZIP": "02368"
+          }
+        }
+      ]
+    }
+  ],
+  "AllergyText": "<table width=\"100%\"><thead><tr><th>Substance</th><th>Reaction</th><th>Severity</th><th>Status</th></tr></thead><tbody><tr><td>Penicillin G benzathine</td><td ID=\"reaction1\">Hives</td><td ID=\"severity1\">Moderate to severe</td><td>Inactive</td></tr><tr><td>Codeine</td><td ID=\"reaction2\">Shortness of Breath</td><td ID=\"severity2\">Moderate</td><td>Active</td></tr><tr><td>Aspirin</td><td ID=\"reaction3\">Hives</td><td ID=\"severity3\">Mild to moderate</td><td>Active</td></tr></tbody></table>",
+  "Allergies": [
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "7982",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Penicillin G benzathine",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "28926001",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Rash",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "255604002",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild"
+          }
+        },
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITH",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "High criticality"
+      },
+      "Status": {
+        "Code": "73425007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Inactive"
+      },
+      "Comments": [
+        {
+          "Text": "Noted when patient took penicillin for ear infection."
+        }
+      ]
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "2670",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Codeine",
+        "AltCodes": [
+          {
+            "Code": "11QV9BS0CB",
+            "CodeSystem": "2.16.840.1.113883.4.9",
+            "CodeSystemName": "UNII",
+            "Name": "Codeine"
+          }
+        ]
+      },
+      "Reaction": [
+        {
+          "Code": "267036007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Shortness of Breath",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "6736007",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "6736007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Moderate"
+      },
+      "Criticality": {
+        "Code": "CRITL",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Low criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    },
+    {
+      "Type": {
+        "Code": "419511003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Propensity to adverse reaction to drug",
+        "AltCodes": []
+      },
+      "Substance": {
+        "Code": "1191",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Aspirin",
+        "AltCodes": []
+      },
+      "Reaction": [
+        {
+          "Code": "247472004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Hives",
+          "AltCodes": [],
+          "Severity": {
+            "Code": "371923003",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Mild to moderate"
+          }
+        }
+      ],
+      "Severity": {
+        "Code": "371923003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Mild to moderate"
+      },
+      "Criticality": {
+        "Code": "CRITU",
+        "CodeSystem": "2.16.840.1.113883.5.1063",
+        "CodeSystemName": "ObservationValue",
+        "Name": "Unable to assess criticality"
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": []
+    }
+  ],
+  "AssessmentText": "<list><item>Recurrent GI bleed of unknown etiology; hypotension perhaps secondary to this but as likely secondary to polypharmacy.</item><item>Acute on chronic anemia secondary to #1.</item><item>Azotemia, acute renal failure with volume loss secondary to #1.</item><item>Hyperkalemia secondary to #3 and on ACE and K+ supplement.</item><item>Other chronic diagnoses as noted above, currently stable.</item></list>Also, this person has back problems.",
+  "Assessment": {
+    "Diagnoses": [
+      {
+        "Value": "Displacement of lumbar intervertebral disc without myelopathy",
+        "DateTime": "2009-11-01T05:00:00.000Z",
+        "IsNegativeIndicator": false,
+        "Codes": [
+          {
+            "Code": "202708005",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED-CT",
+            "Name": "Herniated lumbar intervertebral disc"
+          },
+          {
+            "Code": "M51.26",
+            "CodeSystem": "2.16.840.1.113883.6.90",
+            "CodeSystemName": "ICD-10",
+            "Name": "Herniated lumbar intervertebral disc"
+          }
+        ],
+        "Comments": []
+      },
+      {
+        "Value": "Thoracic or lumbosacral neuritis or radiculitis, unspecified",
+        "DateTime": "2009-11-01T05:00:00.000Z",
+        "IsNegativeIndicator": false,
+        "Codes": [
+          {
+            "Code": "M54.16",
+            "CodeSystem": "2.16.840.1.113883.6.90",
+            "CodeSystemName": "ICD-10",
+            "Name": "Right lumbar radiculopathy"
+          }
+        ],
+        "Comments": []
+      }
+    ]
+  },
+  "CareTeams": [],
+  "ChiefComplaintText": "<paragraph>Dark stools.</paragraph>",
+  "DischargeDiagnosis": [],
+  "DischargeMedications": [],
+  "EncountersText": "<table width=\"100%\"><thead><tr><th>Encounter</th><th>Performer</th><th>Location</th><th>Date</th></tr></thead><tbody><tr ID=\"Encounter1\"><td>Pnuemonia</td><td>Dr Henry Seven</td><td>Community Health and Hospitals</td><td>20120806</td></tr></tbody></table>",
+  "Encounters": [
+    {
+      "Identifiers": [
+        {
+          "ID": "2376492",
+          "IDType": "URMC Epic CSN"
+        },
+        {
+          "ID": "8237334",
+          "IDType": "1.35.829.5.238422.9.10"
+        }
+      ],
+      "Type": {
+        "Code": "99222",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "InPatient Admission",
+        "AltCodes": []
+      },
+      "DateTime": "2012-08-06T04:00:00.000Z",
+      "Providers": [
+        {
+          "Credentials": [],
+          "Address": {},
+          "EmailAddresses": [],
+          "PhoneNumber": {},
+          "Location": {},
+          "Role": {
+            "Code": "59058001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "General Physician",
+            "AltCodes": []
+          }
+        }
+      ],
+      "Locations": [
+        {
+          "Identifiers": [],
+          "Telecom": [],
+          "Address": {
+            "StreetAddress": "1002 Healthcare Dr",
+            "City": "Portland",
+            "State": "OR",
+            "Country": "US",
+            "ZIP": "97266"
+          },
+          "Type": {
+            "Code": "1160-1",
+            "CodeSystem": "2.16.840.1.113883.6.259",
+            "CodeSystemName": "HealthcareServiceLocation",
+            "Name": "Urgent Care Center",
+            "AltCodes": []
+          },
+          "Name": "Community Health and Hospitals"
+        }
+      ],
+      "Diagnosis": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "ReasonForVisit": [
+        {
+          "Code": "233604007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Pneumonia",
+          "AltCodes": []
+        }
+      ],
+      "DischargeDisposition": {
+        "AltCodes": []
+      }
+    }
+  ],
+  "FamilyHistoryText": "<paragraph>Father (deceased)</paragraph><table width=\"100%\"><thead><tr><th>Diagnosis</th><th>Age At Onset</th></tr></thead><tbody><tr><td>Myocardial Infarction (cause of death)</td><td>57</td></tr><tr><td>Diabetes</td><td>40</td></tr></tbody></table>",
+  "FamilyHistory": [
+    {
+      "Relation": {
+        "Code": "FTH",
+        "CodeSystem": "2.16.840.1.113883.5.111",
+        "CodeSystemName": "HL7 FamilyMember",
+        "Name": "Father",
+        "Demographics": {
+          "Sex": "Male",
+          "DOB": "1912-01-01"
+        },
+        "IsDeceased": true
+      },
+      "Problems": [
+        {
+          "Code": "22298006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Myocardial infarction",
+          "AltCodes": [],
+          "Type": {
+            "Code": "55607006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Problem"
+          },
+          "AgeAtOnset": "57"
+        },
+        {
+          "Code": "46635009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Diabetes mellitus type 1",
+          "AltCodes": [],
+          "Type": {
+            "Code": "64572001",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Condition"
+          },
+          "DateTime": "1994-01-01T05:00:00.000Z",
+          "AgeAtOnset": "40"
+        }
+      ]
+    }
+  ],
+  "FunctionalStatusText": "<table><thead><tr><th>Assessment</th><th>Date</th><th>Results</th><th>Comments</th></tr></thead><tbody><tr ID=\"FS_Narrative1\"><td ID=\"FS_Type\">Functional Status</td><td>August 15 2012, 5:32pm</td><td ID=\"FS_Finding1\">Dependence on walking stick</td><td></td></tr><tr ID=\"FS_Narrative2\"><td ID=\"FS_Type\">Functional Status</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent with dressing</td><td></td></tr><tr ID=\"FS_Narrative3\"><td ID=\"FS_Type\">Transferring</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Independent</td><td></td></tr><tr ID=\"FS_Narrative4\"><td ID=\"FS_Type\">Hearing</td><td>March 11 2013</td><td ID=\"FS_Finding1\">Impaired</td><td></td></tr></tbody></table>",
+  "FunctionalStatus": {
+    "Observations": [
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2012-08-15",
+        "CodedValue": {
+          "Code": "105504002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Dependence on walking stick",
+          "AltCodes": []
+        },
+        "Value": "Dependence on walking stick",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "54522-8",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Functional Status",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "129035000",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent with dressing",
+          "AltCodes": []
+        },
+        "Value": "Independent with dressing",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "46482-6",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Transferring",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "371153006",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Independent",
+          "AltCodes": []
+        },
+        "Value": "Independent",
+        "ReferenceRange": {},
+        "Comments": []
+      },
+      {
+        "Code": "47078008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Hearing",
+        "AltCodes": [],
+        "DateTime": "2013-03-11",
+        "CodedValue": {
+          "Code": "260379002",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Impaired",
+          "AltCodes": []
+        },
+        "Value": "Impaired",
+        "ReferenceRange": {},
+        "Comments": []
+      }
+    ],
+    "Supplies": [
+      {
+        "Code": "14106009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cardiac Pacemaker",
+        "AltCodes": [],
+        "Status": "completed",
+        "DateTime": "2013-07-03"
+      }
+    ]
+  },
+  "GoalsText": "<paragraph ID=\"Goals\">Patient is targeting a pulse oximetry of 92%</paragraph>",
+  "Goals": [
+    {
+      "Code": "59408-5",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Oxygen saturation in Arterial blood by Pulse oximetry",
+      "AltCodes": [],
+      "DateTime": "2012-12-31T23:59:59.999Z",
+      "CodedValue": {
+        "AltCodes": []
+      },
+      "Value": "92",
+      "Units": "%",
+      "StartDate": "2013-09-02",
+      "EndDate": "2013-09-02",
+      "Priority": {
+        "Code": "394849002",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "High priority"
+      },
+      "AchievementStatus": {
+        "Name": "On track"
+      },
+      "Milestones": [],
+      "Comments": []
+    }
+  ],
+  "HealthConcernsText": "<table><thead><tr><th>Health Concern</th><th>Date</th><th>Related Problem</th></tr></thead><tbody><tr ID=\"Concern1\"><td ID=\"Concern1Issue1\">Concerned about being contagious and infecting roommate.</td><td>Concern from 03/02/2014</td><td>Community Acquired Pneumonia</td></tr></tbody></table>",
+  "HealthConcerns": [
+    {
+      "Category": {
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "Code": "385093006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Community Acquired Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "TargetSite": {
+        "AltCodes": []
+      },
+      "Status": "active",
+      "Comments": []
+    }
+  ],
+  "HistoryOfPresentIllnessText": "<list><item><caption>Kelp, Lonnie Ray Sr., MD PHD - 10/21/2014 8:07 PM PST</caption><paragraph>Date: 10/21/2014<br/><br/>Pre-procedure diagnosis: L5 S1 Acute Lumbar Radiculopathy (Right)<br/><br/>Post-procedure diagnosis: Same<br/><br/>Procedure: 1) L5S1 Transforaminal Epidural Steroid injection(Right)<br/>2) Fluoroscopic Guidance for needle placement<br/><br/>Complications: None<br/><br/>CONSENT: Today's procedure, its potential benefits as well as its risks and potential side effects were reviewed. Discussed risks of the procedure include bleeding, infection, nerve irritation or damage, reactions to the medications, headache, failure of the pain to improve, and exacerbation of the pain were explained to the patient, who verbalized understanding and who wished to proceed. Informed consent was signed.<br/><br/>DESCRIPTION OF PROCEDURES: After written informed consent was obtained, the patient was taken to the fluoroscopy suite. Anatomical landmarks were identified by way of fluoroscopy in multiple views. Strict aseptic technique was utilized.<br/><br/>A 22-gauge 3-1/2-inch needle was then incrementally advanced using multiple fluoroscopic views from an oblique approach into the Right L5S1 lumbar intervertebral space. Both AP and lateral views were used to confirm final needle placement. After negative aspiration, Omniopaque 240 contrast was injected which delineated epidural without vascular flow and a normal epidurogram under fluoroscopy in the lateral and AP view. After negative aspiration was reconfirmed, a 1.0 mL of 0.25% Bupivicaine and 1mL of 40 mg/mL of Kenalog was slowly injected into the epidural space.<br/><br/>All needles were removed intact. Hemostasis was maintained. There were no complications. The area was cleaned and a Band-Aid placed as necessary. The patient tolerated the procedure well and all needles were removed intact. After a period of observation, the patient was noted to be hemodynamically stable and neurovascularly intact following the procedure as prior to the procedure, and was ultimately discharged to home with supervision in good condition. The patient was instructed to schedule an appointment in the office within 2 weeks.<br/>Lonnie Ray Kelp Sr., MD PHD<br/><br/></paragraph></item></list>",
+  "ImmunizationText": "<table width=\"100%\"><thead><tr><th>Vaccine</th><th>Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"immun2\">Influenza virus vaccine, IM</td><td>May 2012</td><td>Completed</td></tr><tr><td ID=\"immun4\">Tetanus and diphtheria toxoids, IM</td><td>Apr 2012</td><td>Completed</td></tr></tbody></table>",
+  "Immunizations": [
+    {
+      "DateTime": "2012-05-10T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "88",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Influenza virus vaccine",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    },
+    {
+      "DateTime": "2012-04-01T04:00:00.000Z",
+      "Route": {
+        "Code": "C28161",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+        "Name": "Intramuscular injection",
+        "AltCodes": []
+      },
+      "Product": {
+        "Manufacturer": "Health LS - Immuno Inc.",
+        "Code": "103",
+        "CodeSystem": "2.16.840.1.113883.6.59",
+        "CodeSystemName": "CVX",
+        "Name": "Tetanus and diphtheria toxoids - preservative free",
+        "AltCodes": []
+      },
+      "Dose": {
+        "Quantity": "50",
+        "Units": "mcg"
+      }
+    }
+  ],
+  "InstructionsText": "Please carefully follow the subsequent instructions and patient education:<br/><br/><list><item>Floss</item><item>Brush teeth twice daily</item></list><br/><br/>Scarf tying instructions may be found online.",
+  "Insurances": [
+    {
+      "Plan": {
+        "ID": "31572",
+        "IDType": "2.16.840.1.113883.4.642.3.520",
+        "Name": "HMO Deductible Plan"
+      },
+      "Company": {
+        "ID": "60054",
+        "Name": "aetna (60054 0131)",
+        "Address": {
+          "StreetAddress": "PO Box 14080",
+          "City": "Lexington",
+          "State": "KY",
+          "ZIP": "40512-4079",
+          "County": "Fayette",
+          "Country": "US"
+        },
+        "PhoneNumber": "+18089541123"
+      },
+      "GroupNumber": "847025-024-0009",
+      "GroupName": "Accelerator Labs",
+      "EffectiveDate": "2015-01-01",
+      "ExpirationDate": "2020-12-31",
+      "PolicyNumber": "9140860055",
+      "Insured": {
+        "Identifiers": [],
+        "Address": {}
+      }
+    }
+  ],
+  "InterventionsText": "Patient practiced use of novel prosthesis including movements formerly neglected including distal extension and retroflexive hyperextension.",
+  "MedicalEquipmentText": "<table width=\"100%\"><thead><tr><th>Supply/Device</th><th>Date Supplied</th></tr></thead><tbody><tr><td>Automatic implantable cardioverter/defibrillator</td><td>Nov 1999</td></tr><tr><td>Total hip replacement prosthesis</td><td>1998</td></tr><tr><td>Wheelchair</td><td>1999</td></tr></tbody></table>",
+  "MedicalEquipment": [
+    {
+      "Status": "completed",
+      "StartDate": "1999-11-01T05:00:00.000Z",
+      "Quantity": "2",
+      "Comments": [],
+      "Product": {
+        "Code": "72506001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Automatic implantable cardioverter/defibrillator",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1998-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "304120007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Total hip replacement prosthesis",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    },
+    {
+      "Status": "completed",
+      "StartDate": "1999-01-01T05:00:00.000Z",
+      "Comments": [],
+      "Product": {
+        "Code": "58938008",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Wheelchair",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": {},
+        "SafetyObservations": []
+      },
+      "Procedure": {
+        "AltCodes": [],
+        "TargetSite": {
+          "AltCodes": []
+        }
+      }
+    }
+  ],
+  "MedicationsText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Directions</th><th>Start Date</th><th>Status</th><th>Indications</th><th>Fill Instructions</th></tr></thead><tbody><tr><td ID=\"Med1\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td><td>Pneumonia (233604007 SNOMED CT)</td><td ID=\"FillIns\">Generic Substitition Allowed</td></tr></tbody></table>",
+  "Medications": [
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      },
+      "Indications": [],
+      "SupplyOrder": {}
+    },
+    {
+      "Prescription": false,
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "IsPRN": true,
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      },
+      "Indications": [
+        {
+          "Code": "422587007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Nausea",
+          "AltCodes": []
+        }
+      ],
+      "SupplyOrder": {}
+    }
+  ],
+  "MedicationsAdministeredText": "<table width=\"100%\"><thead><tr><th>Medication</th><th>Start Date</th><th>Status</th></tr></thead><tbody><tr><td ID=\"Med2\">Albuterol 0.09 MG/ACTUAT inhalant solution</td><td>0.09 MG/ACTUAT inhalant solution, 2 puffs once</td><td>20120806</td><td>Active</td></tr></tbody></table>",
+  "MedicationsAdministered": [
+    {
+      "Dose": {
+        "Quantity": "4",
+        "Units": "mg"
+      },
+      "Rate": {},
+      "Route": {
+        "Code": "C38288",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "Oral",
+        "AltCodes": []
+      },
+      "StartDate": "2013-11-11T05:00:00.000Z",
+      "Frequency": {
+        "Period": "8",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "104894",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Ondansetron 4 Mg Po Tbdp",
+        "AltCodes": [
+          {
+            "Code": "0378-7732-93",
+            "CodeSystem": "2.16.840.1.113883.6.69",
+            "CodeSystemName": "NDC",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.253",
+            "CodeSystemName": "MDDID",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "50250065007220",
+            "CodeSystem": "2.16.840.1.113883.6.68",
+            "CodeSystemName": "Medispan GPI",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          },
+          {
+            "Code": "64695",
+            "CodeSystem": "2.16.840.1.113883.6.162",
+            "CodeSystemName": "Medispan",
+            "Name": "Ondansetron 4 Mg Po Tbdp"
+          }
+        ]
+      }
+    },
+    {
+      "Dose": {
+        "Quantity": "0.09",
+        "Units": "mg/actuat"
+      },
+      "Rate": {
+        "Quantity": "90",
+        "Units": "ml/min"
+      },
+      "Route": {
+        "Code": "C38216",
+        "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+        "CodeSystemName": "NCI Thesaurus",
+        "Name": "RESPIRATORY (INHALATION)",
+        "AltCodes": []
+      },
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-13T04:00:00.000Z",
+      "Frequency": {
+        "Period": "12",
+        "Unit": "h"
+      },
+      "Product": {
+        "Code": "573621",
+        "CodeSystem": "2.16.840.1.113883.6.88",
+        "CodeSystemName": "RxNorm",
+        "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ObjectiveText": "<list><item>Chest: clear to ausc. No rales, normal breath sounds</item><item>Heart: RR, PMI in normal location and no heave or evidence ofcardiomegaly,normal heart sounds, no murm or gallop</item></list>",
+  "PhysicalExamText": "All examinations performed within normal limits.<br/><br/>WNL<br/><br/>Nothing to report here.",
+  "PlanOfCareText": "<table width=\"100%\"><thead><tr><th>Planned Activity</th><th>Planned Date</th></tr></thead><tbody><tr><td>Consultation with Dr George Potomac for Asthma</td><td>20120820</td></tr><tr><td>Chest X-ray</td><td>20120826</td></tr><tr><td>Sputum Culture</td><td>20120820</td></tr></tbody></table>",
+  "PlanOfCare": {
+    "Orders": [
+      {
+        "Code": "624-7",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "Name": "Sputum Culture",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "Status": "Request",
+        "DateTime": "2012-08-26T05:00:00.000Z"
+      }
+    ],
+    "Encounters": [
+      {
+        "Code": "99241",
+        "CodeSystem": "2.16.840.1.113883.6.12",
+        "CodeSystemName": "CPT",
+        "Name": "Office consultation - 15 minutes",
+        "AltCodes": [],
+        "Identifiers": [],
+        "Status": "Intent",
+        "DateTime": "2012-08-20T05:00:00.000Z"
+      }
+    ],
+    "MedicationAdministration": [
+      {
+        "Status": "Intent",
+        "Dose": {
+          "Quantity": "81",
+          "Units": "milliGRAM(s)"
+        },
+        "Rate": {},
+        "Route": {
+          "Code": "C38288",
+          "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          "CodeSystemName": "NCI Thesaurus",
+          "Name": "ORAL",
+          "AltCodes": []
+        },
+        "StartDate": "2012-10-02T05:00:00.000Z",
+        "EndDate": "2012-10-31T04:59:00.000Z",
+        "Frequency": {},
+        "Product": {
+          "Code": "1191",
+          "CodeSystem": "2.16.840.1.113883.6.88",
+          "CodeSystemName": "RxNorm",
+          "Name": "aspirin",
+          "AltCodes": []
+        }
+      }
+    ],
+    "Supplies": [],
+    "Services": [
+      {
+        "Code": "427519008",
+        "CodeSystem": "2.16.840.1.113883.11.20.9.34",
+        "CodeSystemName": "patientEducationType",
+        "Name": "Caregiver",
+        "AltCodes": [],
+        "Status": "Intent"
+      }
+    ]
+  },
+  "ProblemsText": "<list><item ID=\"problem1\">Pneumonia : Status - Resolved</item><item ID=\"problem2\">Asthma : Status - Active</item></list>",
+  "Problems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "233604007",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Pneumonia",
+      "AltCodes": [
+        {
+          "Code": "J18.9",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Pneumonia"
+        },
+        {
+          "Code": "486",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Pneumonia"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    },
+    {
+      "StartDate": "2007-10-17T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "195967001",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Asthma",
+      "AltCodes": [
+        {
+          "Code": "J45.909",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Asthma"
+        },
+        {
+          "Code": "493.90",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Asthma"
+        }
+      ],
+      "Category": {
+        "Code": "409586006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Complaint",
+        "AltCodes": []
+      },
+      "Status": {
+        "Code": "55561003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Active"
+      },
+      "Comments": [],
+      "HealthStatus": {
+        "Code": "162467007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Symptom Free",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ProceduresText": "<table width=\"100%\"><thead><tr><th>Procedure</th><th>Date</th></tr></thead><tbody><tr><td ID=\"Proc2\">Chest X-Ray</td><td>8/7/2012</td></tr></tbody></table>",
+  "Procedures": {
+    "Observations": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake observation",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "active",
+        "TargetSite": {
+          "Code": "302539009",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire hand (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Procedures": [
+      {
+        "Code": "168731009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Chest X-Ray",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "completed",
+        "TargetSite": {
+          "Code": "181608004",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED-CT",
+          "Name": "Entire chest wall (body structure)",
+          "AltCodes": []
+        },
+        "Comments": []
+      }
+    ],
+    "Services": [
+      {
+        "Code": "123456",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED-CT",
+        "Name": "Fake action",
+        "AltCodes": [],
+        "DateTime": "2012-08-07",
+        "Status": "aborted",
+        "Comments": []
+      }
+    ]
+  },
+  "ResolvedProblemsText": "<list><item ID=\"problem1\">Tobacco abuse : Status - Resolved</item></list>",
+  "ResolvedProblems": [
+    {
+      "StartDate": "2012-08-06T04:00:00.000Z",
+      "EndDate": "2012-08-06T04:00:00.000Z",
+      "Code": "110483000",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Tobacco abuse",
+      "AltCodes": [
+        {
+          "Code": "Z72.0",
+          "CodeSystem": "2.16.840.1.113883.6.90",
+          "CodeSystemName": "ICD-10-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "305.1",
+          "CodeSystem": "2.16.840.1.113883.6.103",
+          "CodeSystemName": "ICD-9-CM",
+          "Name": "Tobacco abuse"
+        },
+        {
+          "Code": "55885",
+          "CodeSystem": "2.16.840.1.113883.3.247.1.1",
+          "CodeSystemName": "Intelligent Medical Objects ProblemIT",
+          "Name": "Tobacco abuse"
+        }
+      ],
+      "Category": {
+        "Code": "64572001",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Tobacco abuse",
+        "AltCodes": [
+          {
+            "Code": "75323-6",
+            "CodeSystem": "2.16.840.1.113883.6.1",
+            "CodeSystemName": "LOINC",
+            "Name": "Tobacco abuse"
+          }
+        ]
+      },
+      "Status": {
+        "Code": "413322009",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Resolved"
+      },
+      "Comments": []
+    }
+  ],
+  "ReasonForReferralText": "<table><colgroup><col width=\"16%\"/><col width=\"16%\"/><col width=\"18%\"/><col width=\"16%\"/><col width=\"16%\"/><col width=\"18%\"/></colgroup><thead><tr><th>Incoming Referral</th><th>Reason</th><th>Specialty</th><th>Diagnoses / Procedures</th><th>Referred By Contact</th><th>Referred To Contact</th></tr></thead><tbody><tr><td><paragraph>Consult, Test &amp; Treat (Routine)</paragraph></td><td/><td>BA-Physical Medicine / Physical Medicine and Rehab</td><td><paragraph>Diagnoses</paragraph><paragraph>Radiculopathy, lumbar region</paragraph><paragraph>L5S1 TTRANSFORMINAL ESI</paragraph><paragraph>L5S1 TTRANSFORMINAL ESI</paragraph><paragraph>Procedures</paragraph><paragraph>PR INJECT ANES/STEROID FORAMEN LUMBAR/SACRAL W IMG GUIDE ,1 LEVEL</paragraph><paragraph>INJECTION</paragraph></td><td><paragraph>Kelp, Lonnie Ray Sr., MD PHD</paragraph></td><td><paragraph>Kelp, Lonnie Ray Sr., MD PHD</paragraph></td></tr></tbody></table>",
+  "ReasonForVisitText": "<paragraph>Light stools.</paragraph>",
+  "ReasonForVisit": [
+    {
+      "Code": "27731006",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "Soft stool",
+      "AltCodes": [],
+      "Category": {
+        "Code": "8661-1",
+        "CodeSystem": "2.16.840.1.113883.6.1",
+        "CodeSystemName": "LOINC",
+        "Name": "Chief Complaint",
+        "AltCodes": []
+      }
+    }
+  ],
+  "ResultText": "<table><tbody><tr><td colspan=\"2\">LABORATORY INFORMATION</td></tr><tr><td colspan=\"2\">Chemistries and drug levels</td></tr><tr><td ID=\"result1\">HGB (M 13-18 g/dl; F 12-16 g/dl)</td><td>13.2</td></tr><tr><td ID=\"result2\">WBC (4.3-10.8 10+3/ul)</td><td>6.7</td></tr><tr><td ID=\"result3\">PLT (135-145 meq/l)</td><td>123 (L)</td></tr></tbody></table>",
+  "Results": [
+    {
+      "Code": "43789009",
+      "CodeSystem": "2.16.840.1.113883.6.96",
+      "CodeSystemName": "SNOMED CT",
+      "Name": "CBC WO DIFFERENTIAL",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "Final",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "CollectionDateTime": "2012-08-10T14:00:00.000Z",
+        "Identifiers": [
+          "1.2.840.113840.5^BL-201201-01"
+        ],
+        "Source": {
+          "Code": "420135007",
+          "CodeSystem": "2.16.840.1.113883.6.96",
+          "CodeSystemName": "SNOMED CT",
+          "Name": "Blood, whole"
+        },
+        "TargetSite": {
+          "Code": "LA",
+          "CodeSystem": "2.16.840.1.113883.18.81",
+          "CodeSystemName": "Body Site",
+          "Name": "Left Arm"
+        }
+      },
+      "Observations": [
+        {
+          "Code": "30313-1",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "HGB",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "10.2",
+          "ValueType": "PhysicalQuantity",
+          "Units": "g/dl",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "33765-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "WBC",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Normal",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "12.3",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        },
+        {
+          "Code": "26515-7",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "PLT",
+          "AltCodes": [],
+          "Status": "Final",
+          "Interpretation": "Low",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "AltCodes": []
+          },
+          "Value": "123",
+          "ValueType": "PhysicalQuantity",
+          "Units": "10+3/ul",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "Code": "624-7",
+      "CodeSystem": "2.16.840.1.113883.6.1",
+      "CodeSystemName": "LOINC",
+      "Name": "Sputum Culture",
+      "AltCodes": [],
+      "Encounter": {
+        "Identifiers": [],
+        "Type": {
+          "AltCodes": []
+        }
+      },
+      "Status": "In Progress",
+      "Producer": {
+        "ID": "RL001",
+        "Name": "Redox Lab WI",
+        "Address": {
+          "StreetAddress": "111 W. Fairchild",
+          "City": "Madison",
+          "State": "WI",
+          "ZIP": "53703",
+          "County": "Dane",
+          "Country": "USA"
+        }
+      },
+      "Specimen": {
+        "Identifiers": [],
+        "Source": {},
+        "TargetSite": {}
+      },
+      "Observations": [
+        {
+          "Code": "86243-3",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Color of Sputum",
+          "AltCodes": [],
+          "Status": "Final",
+          "DateTime": "2012-08-10T14:00:00.000Z",
+          "CodedValue": {
+            "Code": "54662009",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Green",
+            "AltCodes": []
+          },
+          "Value": "Green",
+          "ValueType": "Code",
+          "ReferenceRange": {},
+          "Comments": []
+        }
+      ]
+    }
+  ],
+  "ReviewOfSystemsText": "<paragraph>Patient denies recent history of fever or malaise. Positive for weakness and shortness of breath. One episode of melena. No recent headaches. Positive for osteoarthritis in hips, knees and hands.</paragraph>",
+  "SocialHistoryText": "<table width=\"100%\"><thead><tr><th>Social History Element</th><th>Description</th><th>Effective Dates</th></tr></thead><tbody><tr><td ID=\"soc1\">smoking</td><td>Former Smoker (1 pack per day</td><td>20050501 to 20110227</td></tr><tr><td ID=\"soc2\">smoking</td><td>Current Everyday Smoker 2 packs per day</td><td>20110227 - today</td></tr></tbody></table>",
+  "SocialHistory": {
+    "Observations": [
+      {
+        "Code": "160573003",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Alcohol Consumption",
+        "AltCodes": [],
+        "Value": {
+          "AltCodes": []
+        },
+        "ValueText": "None",
+        "StartDate": "1990-05-01T04:00:00.000Z",
+        "Comments": []
+      }
+    ],
+    "Pregnancy": [],
+    "TobaccoUse": [
+      {
+        "Code": "8517006",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Former smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": true,
+        "StartDate": "2015-06-03T09:35:00.000Z",
+        "Comments": []
+      },
+      {
+        "Code": "65568007",
+        "CodeSystem": "2.16.840.1.113883.6.96",
+        "CodeSystemName": "SNOMED CT",
+        "Name": "Cigarette smoker",
+        "AltCodes": [],
+        "IsSmokingStatus": false,
+        "StartDate": "2005-05-01",
+        "EndDate": "2008-09-01",
+        "Comments": []
+      }
+    ]
+  },
+  "SubjectiveText": "<paragraph> Complaints of rectal bleeding, fatigue and a change in bowel patterns. Has several days of constipation alternating with diarrhea. </paragraph>",
+  "VitalSignsText": "<table width=\"100%\"><thead><tr><th align=\"right\">Date / Time: </th><th>Nov 1, 2011</th><th>August 6, 2012</th></tr></thead><tbody><tr><th align=\"left\">Height</th><td ID=\"vit1\">69 inches</td><td ID=\"vit2\">69 inches</td></tr><tr><th align=\"left\">Weight</th><td ID=\"vit3\">189 lbs</td><td ID=\"vit4\">194 lbs</td></tr><tr><th align=\"left\">Blood Pressure</th><td ID=\"vit5\">132/86 mmHg</td><td ID=\"vit6\">145/88 mmHg</td></tr></tbody></table>",
+  "VitalSigns": [
+    {
+      "DateTime": "1999-11-14T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "86",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "1999-11-14T00:00:00.000Z",
+          "Value": "132",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    },
+    {
+      "DateTime": "2000-04-07T00:00:00.000Z",
+      "Observations": [
+        {
+          "Code": "8302-2",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Height",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "177",
+          "Units": "cm",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "3141-9",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Patient Body Weight - Measured",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "88",
+          "Units": "kg",
+          "TargetSite": {
+            "AltCodes": []
+          },
+          "Comments": []
+        },
+        {
+          "Code": "8480-6",
+          "CodeSystem": "2.16.840.1.113883.6.1",
+          "CodeSystemName": "LOINC",
+          "Name": "Intravascular Systolic",
+          "AltCodes": [],
+          "Status": "completed",
+          "Interpretation": "Normal",
+          "DateTime": "2000-04-07T00:00:00.000Z",
+          "Value": "145",
+          "Units": "mm[Hg]",
+          "TargetSite": {
+            "Code": "368208006",
+            "CodeSystem": "2.16.840.1.113883.6.96",
+            "CodeSystemName": "SNOMED CT",
+            "Name": "Left upper arm structure",
+            "AltCodes": []
+          },
+          "Comments": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/device_new.json
+++ b/tests/fixtures/device_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Device",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/financial_accountupdate.json
+++ b/tests/fixtures/financial_accountupdate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Financial",
     "EventType": "AccountUpdate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/financial_transaction.json
+++ b/tests/fixtures/financial_transaction.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Financial",
     "EventType": "Transaction",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/flowsheet_new.json
+++ b/tests/fixtures/flowsheet_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Flowsheet",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/inventory_deplete.json
+++ b/tests/fixtures/inventory_deplete.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Inventory",
     "EventType": "Deplete",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/inventory_update.json
+++ b/tests/fixtures/inventory_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Inventory",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/media_delete.json
+++ b/tests/fixtures/media_delete.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Media",
     "EventType": "Delete",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/media_new.json
+++ b/tests/fixtures/media_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Media",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/media_query.json
+++ b/tests/fixtures/media_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Media",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/media_queryresponse.json
+++ b/tests/fixtures/media_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Media",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/media_replace.json
+++ b/tests/fixtures/media_replace.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Media",
     "EventType": "Replace",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/medications_administration.json
+++ b/tests/fixtures/medications_administration.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Medications",
     "EventType": "Administration",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -69,7 +69,7 @@
     "Notes": []
   },
   "Visit": {
-    "VisitDateTime": "2022-08-01T18:38:57.975Z",
+    "VisitDateTime": "2022-08-03T18:06:44.432Z",
     "VisitNumber": "1234",
     "Location": {},
     "AttendingProvider": {
@@ -92,7 +92,7 @@
       "Status": "Complete",
       "Medication": {
         "Order": {
-          "ID": "c25aa357-02c4-4eba-835a-8efe311f2d87"
+          "ID": "fd4cc716-8542-4431-8a0c-f62f37699aa6"
         },
         "Dose": {
           "Quantity": 4,
@@ -116,7 +116,7 @@
         },
         "Indications": []
       },
-      "StartDate": "2022-08-01T18:38:57.069Z",
+      "StartDate": "2022-08-03T18:06:43.593Z",
       "AdministeringProvider": {
         "NPI": "4356789876",
         "ID": "4356789876",

--- a/tests/fixtures/medications_cancel.json
+++ b/tests/fixtures/medications_cancel.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Medications",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -96,7 +96,7 @@
     ]
   },
   "Visit": {
-    "VisitDateTime": "2022-08-01T18:38:57.970Z",
+    "VisitDateTime": "2022-08-03T18:06:44.425Z",
     "VisitNumber": "1234",
     "Location": {},
     "AttendingProvider": {
@@ -116,7 +116,7 @@
     "Insurances": []
   },
   "Order": {
-    "ID": "61ceb7d7-9b3f-466a-9b8f-c60deeff2d2a",
+    "ID": "276ca263-5d1c-40d1-9c78-8c3f0cd08ec3",
     "Notes": [],
     "Medication": {
       "Dose": {
@@ -139,7 +139,7 @@
         "Name": "Ondansetron 4 Mg Po Tbdp",
         "AltCodes": []
       },
-      "StartDate": "2022-08-01T18:38:57.069Z",
+      "StartDate": "2022-08-03T18:06:43.593Z",
       "Frequency": {
         "Period": 8,
         "Unit": "h"

--- a/tests/fixtures/medications_new.json
+++ b/tests/fixtures/medications_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Medications",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -96,7 +96,7 @@
     ]
   },
   "Visit": {
-    "VisitDateTime": "2022-08-01T18:38:57.943Z",
+    "VisitDateTime": "2022-08-03T18:06:44.401Z",
     "VisitNumber": "1234",
     "Location": {},
     "AttendingProvider": {
@@ -116,7 +116,7 @@
     "Insurances": []
   },
   "Order": {
-    "ID": "b5e3adcd-08ae-4a29-a394-2833c7682c20",
+    "ID": "4e87f33a-e40c-4821-88cd-81c8c94884e5",
     "Notes": [],
     "Medication": {
       "Dose": {
@@ -139,7 +139,7 @@
         "Name": "Ondansetron 4 Mg Po Tbdp",
         "AltCodes": []
       },
-      "StartDate": "2022-08-01T18:38:57.069Z",
+      "StartDate": "2022-08-03T18:06:43.593Z",
       "Frequency": {
         "Period": 8,
         "Unit": "h"

--- a/tests/fixtures/medications_update.json
+++ b/tests/fixtures/medications_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Medications",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -96,7 +96,7 @@
     ]
   },
   "Visit": {
-    "VisitDateTime": "2022-08-01T18:38:57.960Z",
+    "VisitDateTime": "2022-08-03T18:06:44.413Z",
     "VisitNumber": "1234",
     "Location": {},
     "AttendingProvider": {
@@ -116,7 +116,7 @@
     "Insurances": []
   },
   "Order": {
-    "ID": "e5ac68bd-46ca-4b2a-9444-2d86b7e45985",
+    "ID": "132e63eb-b242-4fe8-90fb-9d541eccb81d",
     "Notes": [],
     "Medication": {
       "Dose": {
@@ -139,7 +139,7 @@
         "Name": "Ondansetron 4 Mg Po Tbdp",
         "AltCodes": []
       },
-      "StartDate": "2022-08-01T18:38:57.069Z",
+      "StartDate": "2022-08-03T18:06:43.593Z",
       "Frequency": {
         "Period": 8,
         "Unit": "h"

--- a/tests/fixtures/notes_delete.json
+++ b/tests/fixtures/notes_delete.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Notes",
     "EventType": "Delete",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/notes_new.json
+++ b/tests/fixtures/notes_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Notes",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/notes_query.json
+++ b/tests/fixtures/notes_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Notes",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/notes_queryresponse.json
+++ b/tests/fixtures/notes_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Notes",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/notes_replace.json
+++ b/tests/fixtures/notes_replace.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Notes",
     "EventType": "Replace",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/order_cancel.json
+++ b/tests/fixtures/order_cancel.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/order_groupedorders.json
+++ b/tests/fixtures/order_groupedorders.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "GroupedOrders",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/order_new.json
+++ b/tests/fixtures/order_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/order_query.json
+++ b/tests/fixtures/order_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/order_queryresponse.json
+++ b/tests/fixtures/order_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/order_update.json
+++ b/tests/fixtures/order_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Order",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/organization_new.json
+++ b/tests/fixtures/organization_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Organization",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/organization_query.json
+++ b/tests/fixtures/organization_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Organization",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/organization_queryresponse.json
+++ b/tests/fixtures/organization_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Organization",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/organization_update.json
+++ b/tests/fixtures/organization_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Organization",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientadmin_arrival.json
+++ b/tests/fixtures/patientadmin_arrival.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "Arrival",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,7 +148,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.083Z",
+    "VisitDateTime": "2022-08-03T18:06:44.529Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/patientadmin_cancel.json
+++ b/tests/fixtures/patientadmin_cancel.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "CanceledEvent": "Arrival",
     "Test": true,
     "Source": {
@@ -149,7 +149,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.088Z",
+    "VisitDateTime": "2022-08-03T18:06:44.539Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/patientadmin_censusquery.json
+++ b/tests/fixtures/patientadmin_censusquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "CensusQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/patientadmin_censusqueryresponse.json
+++ b/tests/fixtures/patientadmin_censusqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "CensusQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -70,7 +70,7 @@
       "Visits": [
         {
           "VisitNumber": "1234",
-          "VisitDateTime": "2022-08-01T18:38:58.154Z",
+          "VisitDateTime": "2022-08-03T18:06:44.604Z",
           "PatientClass": "Inpatient",
           "Location": {
             "Type": "Inpatient",

--- a/tests/fixtures/patientadmin_discharge.json
+++ b/tests/fixtures/patientadmin_discharge.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "Discharge",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,8 +148,8 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-07-31T18:38:58.094Z",
-    "DischargeDateTime": "2022-08-01T18:38:58.094Z",
+    "VisitDateTime": "2022-08-02T18:06:44.549Z",
+    "DischargeDateTime": "2022-08-03T18:06:44.549Z",
     "DischargeStatus": {
       "Code": "01",
       "Codeset": "UB04FL17",

--- a/tests/fixtures/patientadmin_newpatient.json
+++ b/tests/fixtures/patientadmin_newpatient.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "NewPatient",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientadmin_patientmerge.json
+++ b/tests/fixtures/patientadmin_patientmerge.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "PatientMerge",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientadmin_patientupdate.json
+++ b/tests/fixtures/patientadmin_patientupdate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "PatientUpdate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientadmin_preadmit.json
+++ b/tests/fixtures/patientadmin_preadmit.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "PreAdmit",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,7 +148,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.118Z",
+    "VisitDateTime": "2022-08-03T18:06:44.573Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/patientadmin_registration.json
+++ b/tests/fixtures/patientadmin_registration.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "Registration",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,7 +148,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.130Z",
+    "VisitDateTime": "2022-08-03T18:06:44.579Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/patientadmin_transfer.json
+++ b/tests/fixtures/patientadmin_transfer.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "Transfer",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,7 +148,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.141Z",
+    "VisitDateTime": "2022-08-03T18:06:44.586Z",
     "DischargeStatus": {
       "Code": "09",
       "Codeset": "UB04FL17",

--- a/tests/fixtures/patientadmin_visitmerge.json
+++ b/tests/fixtures/patientadmin_visitmerge.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "VisitMerge",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientadmin_visitquery.json
+++ b/tests/fixtures/patientadmin_visitquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "VisitQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -59,5 +59,5 @@
     "1234",
     "5678"
   ],
-  "VisitStartDateTime": "2022-08-01T18:38:58.156Z"
+  "VisitStartDateTime": "2022-08-03T18:06:44.605Z"
 }

--- a/tests/fixtures/patientadmin_visitqueryresponse.json
+++ b/tests/fixtures/patientadmin_visitqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "VisitQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -70,7 +70,7 @@
       "Visits": [
         {
           "VisitNumber": "1234",
-          "VisitDateTime": "2022-08-01T18:38:58.161Z",
+          "VisitDateTime": "2022-08-03T18:06:44.609Z",
           "PatientClass": "Inpatient",
           "Location": {
             "Type": "Inpatient",

--- a/tests/fixtures/patientadmin_visitupdate.json
+++ b/tests/fixtures/patientadmin_visitupdate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientAdmin",
     "EventType": "VisitUpdate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -148,7 +148,7 @@
   "Visit": {
     "VisitNumber": "1234",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:58.149Z",
+    "VisitDateTime": "2022-08-03T18:06:44.597Z",
     "Duration": 30,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/patienteducation_delete.json
+++ b/tests/fixtures/patienteducation_delete.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientEducation",
     "EventType": "Delete",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -71,7 +71,7 @@
     "VisitNumber": "3498128348",
     "AccountNumber": "12945932",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:57.048Z",
+    "VisitDateTime": "2022-08-03T18:06:43.574Z",
     "AttendingProvider": {
       "ID": "426986",
       "IDType": "NCT",
@@ -148,7 +148,7 @@
         "Description": "Diet and Nutrition"
       },
       "InstanceID": "20898465",
-      "CreatedDateTime": "2022-08-01T18:38:58.170Z",
+      "CreatedDateTime": "2022-08-03T18:06:44.617Z",
       "Status": "Active",
       "ActionStatus": "Assign",
       "Assignments": [
@@ -162,7 +162,7 @@
             "Description": "Diet and Nutrition in Pregnancy"
           },
           "InstanceID": "87300586",
-          "CreatedDateTime": "2022-08-01T18:38:57.048Z",
+          "CreatedDateTime": "2022-08-03T18:06:43.574Z",
           "Status": "Active",
           "ActionStatus": "Assign",
           "Assignees": [

--- a/tests/fixtures/patienteducation_new.json
+++ b/tests/fixtures/patienteducation_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientEducation",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -71,7 +71,7 @@
     "VisitNumber": "3498128348",
     "AccountNumber": "12945932",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:57.048Z",
+    "VisitDateTime": "2022-08-03T18:06:43.574Z",
     "AttendingProvider": {
       "ID": "426986",
       "IDType": "NCT",
@@ -148,7 +148,7 @@
         "Description": "Diet and Nutrition"
       },
       "InstanceID": "20898465",
-      "CreatedDateTime": "2022-08-01T18:38:58.163Z",
+      "CreatedDateTime": "2022-08-03T18:06:44.612Z",
       "Status": "Active",
       "ActionStatus": "Assign",
       "Assignments": [
@@ -162,7 +162,7 @@
             "Description": "Diet and Nutrition in Pregnancy"
           },
           "InstanceID": "87300586",
-          "CreatedDateTime": "2022-08-01T18:38:57.048Z",
+          "CreatedDateTime": "2022-08-03T18:06:43.574Z",
           "Status": "Active",
           "ActionStatus": "Assign",
           "Assignees": [

--- a/tests/fixtures/patienteducation_update.json
+++ b/tests/fixtures/patienteducation_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientEducation",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -71,7 +71,7 @@
     "VisitNumber": "3498128348",
     "AccountNumber": "12945932",
     "PatientClass": "Inpatient",
-    "VisitDateTime": "2022-08-01T18:38:57.048Z",
+    "VisitDateTime": "2022-08-03T18:06:43.574Z",
     "AttendingProvider": {
       "ID": "426986",
       "IDType": "NCT",
@@ -148,7 +148,7 @@
         "Description": "Diet and Nutrition"
       },
       "InstanceID": "20898465",
-      "CreatedDateTime": "2022-08-01T18:38:58.164Z",
+      "CreatedDateTime": "2022-08-03T18:06:44.614Z",
       "Status": "Active",
       "ActionStatus": "Assign",
       "Assignments": [
@@ -162,7 +162,7 @@
             "Description": "Diet and Nutrition in Pregnancy"
           },
           "InstanceID": "87300586",
-          "CreatedDateTime": "2022-08-01T18:38:57.048Z",
+          "CreatedDateTime": "2022-08-03T18:06:43.574Z",
           "Status": "Active",
           "ActionStatus": "Assign",
           "Assignees": [

--- a/tests/fixtures/patientsearch_locationquery.json
+++ b/tests/fixtures/patientsearch_locationquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientSearch",
     "EventType": "LocationQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/patientsearch_locationqueryresponse.json
+++ b/tests/fixtures/patientsearch_locationqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientSearch",
     "EventType": "LocationQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/patientsearch_query.json
+++ b/tests/fixtures/patientsearch_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientSearch",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/patientsearch_response.json
+++ b/tests/fixtures/patientsearch_response.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "PatientSearch",
     "EventType": "Response",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/provider_activate.json
+++ b/tests/fixtures/provider_activate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "Activate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/provider_deactivate.json
+++ b/tests/fixtures/provider_deactivate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "Deactivate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/provider_new.json
+++ b/tests/fixtures/provider_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/provider_providerquery.json
+++ b/tests/fixtures/provider_providerquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "ProviderQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/provider_providerqueryresponse.json
+++ b/tests/fixtures/provider_providerqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "ProviderQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/provider_update.json
+++ b/tests/fixtures/provider_update.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Provider",
     "EventType": "Update",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_authresponse.json
+++ b/tests/fixtures/referral_authresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "AuthResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_authreview.json
+++ b/tests/fixtures/referral_authreview.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "AuthReview",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_cancel.json
+++ b/tests/fixtures/referral_cancel.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_modify.json
+++ b/tests/fixtures/referral_modify.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "Modify",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_new.json
+++ b/tests/fixtures/referral_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/referral_query.json
+++ b/tests/fixtures/referral_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/referral_queryresponse.json
+++ b/tests/fixtures/referral_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Referral",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/research_study.json
+++ b/tests/fixtures/research_study.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Research",
     "EventType": "Study",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/research_subjectupdate.json
+++ b/tests/fixtures/research_subjectupdate.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Research",
     "EventType": "SubjectUpdate",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/results_new.json
+++ b/tests/fixtures/results_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Results",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/results_newunsolicited.json
+++ b/tests/fixtures/results_newunsolicited.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Results",
     "EventType": "NewUnsolicited",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/results_query.json
+++ b/tests/fixtures/results_query.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Results",
     "EventType": "Query",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/results_queryresponse.json
+++ b/tests/fixtures/results_queryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Results",
     "EventType": "QueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/scheduling_availableslots.json
+++ b/tests/fixtures/scheduling_availableslots.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "AvailableSlots",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/scheduling_availableslotsresponse.json
+++ b/tests/fixtures/scheduling_availableslotsresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "AvailableSlotsResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/scheduling_booked.json
+++ b/tests/fixtures/scheduling_booked.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "Booked",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "StartDateTime": "2022-08-01T18:38:58.383Z",
+  "StartDateTime": "2022-08-03T18:06:44.805Z",
   "Visit": {
     "AttendingProviders": [
       {

--- a/tests/fixtures/scheduling_bookedresponse.json
+++ b/tests/fixtures/scheduling_bookedresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "BookedResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/scheduling_cancel.json
+++ b/tests/fixtures/scheduling_cancel.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -84,7 +84,7 @@
   ],
   "Visit": {
     "VisitNumber": "1234",
-    "VisitDateTime": "2022-08-01T18:38:58.357Z",
+    "VisitDateTime": "2022-08-03T18:06:44.776Z",
     "Duration": 15,
     "Reason": "Check up",
     "CancelReason": "Conflicting appointment",

--- a/tests/fixtures/scheduling_modification.json
+++ b/tests/fixtures/scheduling_modification.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "Modification",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -84,7 +84,7 @@
   ],
   "Visit": {
     "VisitNumber": "1234",
-    "VisitDateTime": "2022-08-01T18:38:58.334Z",
+    "VisitDateTime": "2022-08-03T18:06:44.768Z",
     "Duration": 30,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/scheduling_new.json
+++ b/tests/fixtures/scheduling_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -84,7 +84,7 @@
   ],
   "Visit": {
     "VisitNumber": "1234",
-    "VisitDateTime": "2022-08-01T18:38:58.305Z",
+    "VisitDateTime": "2022-08-03T18:06:44.756Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/scheduling_noshow.json
+++ b/tests/fixtures/scheduling_noshow.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "NoShow",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -84,7 +84,7 @@
   ],
   "Visit": {
     "VisitNumber": "1234",
-    "VisitDateTime": "2022-08-01T18:38:58.365Z",
+    "VisitDateTime": "2022-08-03T18:06:44.781Z",
     "Duration": 15,
     "Reason": "Check up",
     "NoShowReason": "Car broke down.",

--- a/tests/fixtures/scheduling_pushslots.json
+++ b/tests/fixtures/scheduling_pushslots.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "PushSlots",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/scheduling_reschedule.json
+++ b/tests/fixtures/scheduling_reschedule.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Scheduling",
     "EventType": "Reschedule",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -85,8 +85,8 @@
   "Visit": {
     "VisitNumber": "1234",
     "OldVisitNumber": "1234",
-    "VisitDateTime": "2022-08-08T18:38:58.319Z",
-    "OldDateTime": "2022-08-01T18:38:58.319Z",
+    "VisitDateTime": "2022-08-10T18:06:44.763Z",
+    "OldDateTime": "2022-08-03T18:06:44.763Z",
     "Duration": 15,
     "Reason": "Check up",
     "Instructions": [],

--- a/tests/fixtures/sso_signon.json
+++ b/tests/fixtures/sso_signon.json
@@ -18,8 +18,8 @@
     ]
   },
   "Subject": "https://healtsystem.com/provider/4356789876",
-  "Expiration": "2022-08-01T18:53:58.392Z",
-  "IssuedAt": "2022-08-01T18:38:58.392Z",
+  "Expiration": "2022-08-03T18:21:44.820Z",
+  "IssuedAt": "2022-08-03T18:06:44.820Z",
   "Name": "Pat Granite MD",
   "FirstName": "Pat",
   "LastName": "Granite",

--- a/tests/fixtures/surgicalscheduling_cancel.json
+++ b/tests/fixtures/surgicalscheduling_cancel.json
@@ -44,7 +44,7 @@
   "Meta": {
     "DataModel": "SurgicalScheduling",
     "EventType": "Cancel",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/surgicalscheduling_modification.json
+++ b/tests/fixtures/surgicalscheduling_modification.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "SurgicalScheduling",
     "EventType": "Modification",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/surgicalscheduling_new.json
+++ b/tests/fixtures/surgicalscheduling_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "SurgicalScheduling",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/surgicalscheduling_noshow.json
+++ b/tests/fixtures/surgicalscheduling_noshow.json
@@ -44,7 +44,7 @@
   "Meta": {
     "DataModel": "SurgicalScheduling",
     "EventType": "NoShow",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/surgicalscheduling_reschedule.json
+++ b/tests/fixtures/surgicalscheduling_reschedule.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "SurgicalScheduling",
     "EventType": "Reschedule",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
@@ -128,7 +128,7 @@
   ],
   "Visit": {
     "VisitNumber": "1234",
-    "VisitDateTime": "2022-08-08T18:38:58.404Z",
+    "VisitDateTime": "2022-08-10T18:06:44.838Z",
     "Notes": [],
     "AttendingProvider": {
       "ID": "4356789876",

--- a/tests/fixtures/vaccination_administration.json
+++ b/tests/fixtures/vaccination_administration.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Vaccination",
     "EventType": "Administration",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/vaccination_new.json
+++ b/tests/fixtures/vaccination_new.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Vaccination",
     "EventType": "New",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/fixtures/vaccination_patientquery.json
+++ b/tests/fixtures/vaccination_patientquery.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Vaccination",
     "EventType": "PatientQuery",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Destinations": [
       {

--- a/tests/fixtures/vaccination_patientqueryresponse.json
+++ b/tests/fixtures/vaccination_patientqueryresponse.json
@@ -2,7 +2,7 @@
   "Meta": {
     "DataModel": "Vaccination",
     "EventType": "PatientQueryResponse",
-    "EventDateTime": "2022-08-01T18:38:57.072Z",
+    "EventDateTime": "2022-08-03T18:06:43.597Z",
     "Test": true,
     "Source": {
       "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",

--- a/tests/get_fixtures.py
+++ b/tests/get_fixtures.py
@@ -68,6 +68,7 @@ def save_fixture(sample: str):
     with open(dest_file, "w") as fixture_file:
         click.echo(f"Writing file {dest_file}")
         dump(sample_dict, fixture_file, indent=2)
+        fixture_file.write("\n")
 
 
 @click.command()

--- a/tests/test_pydantic_round_trip.py
+++ b/tests/test_pydantic_round_trip.py
@@ -23,11 +23,7 @@ SAMPLE_DATA_FILE_PATH = [
 SKIP_FILES = [
     str(SAMPLES_DIR / f)
     for f in [
-        "clinicalsummary_patientpush.json",
-        "clinicalsummary_visitpush.json",
-        "clinicalsummary_visitqueryresponse.json",
-        "clinicalsummary_patientqueryresponse.json",
-        "clinicaldecisions_request.json",
+        # "clinicaldecisions_request.json",
     ]
 ]
 


### PR DESCRIPTION
Fixes #18 

This is directly caused by issues with the Redox schema, which contains instances where fields have a declared type like this:

```json
"type": [
  "null",
  "null"
]
```

This seems too strange to be intentional. Adding this as a topic of discussion with Redox (#19)